### PR TITLE
chore: migrate to Zod v4 across all packages and apps

### DIFF
--- a/.changeset/zod-v4-migration.md
+++ b/.changeset/zod-v4-migration.md
@@ -1,0 +1,6 @@
+---
+"@nest-mcp/common": patch
+"@nest-mcp/server": patch
+---
+
+Migrate to Zod v4. Zod v4 is now the required peer dependency.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ npm install @nest-mcp/gateway @modelcontextprotocol/sdk
 Peer dependencies (all packages):
 
 ```bash
-npm install @nestjs/common @nestjs/core reflect-metadata rxjs zod
+npm install @nestjs/common @nestjs/core reflect-metadata rxjs zod@^4
 ```
 
 > **Note:** `zod@^4` is required. Zod v3 is not supported.

--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ npm install @nest-mcp/gateway @modelcontextprotocol/sdk
 Peer dependencies (all packages):
 
 ```bash
-npm install @nestjs/common @nestjs/core reflect-metadata rxjs
+npm install @nestjs/common @nestjs/core reflect-metadata rxjs zod
 ```
+
+> **Note:** `zod@^4` is required. Zod v3 is not supported.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,6 @@ Peer dependencies (all packages):
 npm install @nestjs/common @nestjs/core reflect-metadata rxjs zod@^4
 ```
 
-> **Note:** `zod@^4` is required. Zod v3 is not supported.
-
 ## Quick start
 
 ### Server

--- a/apps/example-browser-mcp/package.json
+++ b/apps/example-browser-mcp/package.json
@@ -27,7 +27,7 @@
     "rxjs": "^7.8.0",
     "turndown": "^7.1.2",
     "turndown-plugin-gfm": "^1.0.2",
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.6",

--- a/apps/example-browser-mcp/package.json
+++ b/apps/example-browser-mcp/package.json
@@ -27,7 +27,7 @@
     "rxjs": "^7.8.0",
     "turndown": "^7.1.2",
     "turndown-plugin-gfm": "^1.0.2",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.6",

--- a/apps/example-postgres-mcp/package.json
+++ b/apps/example-postgres-mcp/package.json
@@ -25,7 +25,7 @@
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/pg": "^8.11.0",

--- a/apps/example-postgres-mcp/package.json
+++ b/apps/example-postgres-mcp/package.json
@@ -4,12 +4,15 @@
   "private": true,
   "description": "Example MCP server for PostgreSQL database inspection and querying (streamable HTTP transport)",
   "bin": {
-    "mcp-postgres": "dist/main.js"
+    "mcp-postgres": "dist/main.js",
+    "mcp-postgres-stdio": "dist/main.stdio.js"
   },
   "scripts": {
     "build": "tsc",
     "start": "node dist/main.js",
     "start:dev": "tsc --outDir dist && node dist/main.js",
+    "start:stdio": "node dist/main.stdio.js",
+    "start:stdio:dev": "tsc --outDir dist && node dist/main.stdio.js",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
@@ -22,7 +25,7 @@
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/pg": "^8.11.0",

--- a/apps/example-postgres-mcp/src/app-stdio.module.ts
+++ b/apps/example-postgres-mcp/src/app-stdio.module.ts
@@ -1,0 +1,26 @@
+import { McpModule, McpTransportType } from '@nest-mcp/server';
+import { Module } from '@nestjs/common';
+import { DatabaseService } from './database/database.service';
+import { QueryPrompts } from './prompts/query.prompts';
+import { SchemaResources } from './resources/schema.resources';
+import { QueryTools } from './tools/query.tools';
+import { SchemaTools } from './tools/schema.tools';
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: 'postgres-mcp',
+      version: '0.1.0',
+      description:
+        'MCP server for PostgreSQL: schema inspection, SQL execution, query analysis, and performance insights',
+      transport: McpTransportType.STDIO,
+      capabilities: {
+        tools: { listChanged: false },
+        resources: { subscribe: false, listChanged: false },
+        prompts: { listChanged: false },
+      },
+    }),
+  ],
+  providers: [DatabaseService, QueryTools, SchemaTools, SchemaResources, QueryPrompts],
+})
+export class AppStdioModule {}

--- a/apps/example-postgres-mcp/src/main.stdio.ts
+++ b/apps/example-postgres-mcp/src/main.stdio.ts
@@ -1,0 +1,26 @@
+import 'reflect-metadata';
+import { StdioService, bootstrapStdioApp } from '@nest-mcp/server';
+import { AppStdioModule } from './app-stdio.module';
+
+async function bootstrap() {
+  const app = await bootstrapStdioApp(AppStdioModule);
+
+  const stdioService = app.get(StdioService);
+  await stdioService.start();
+
+  process.stderr.write('Postgres MCP stdio server started. Communicating via stdin/stdout.\n');
+  process.stderr.write(
+    `Read-only mode: ${process.env['POSTGRES_READONLY'] === 'true' ? 'enabled' : 'disabled'}\n`,
+  );
+
+  process.on('SIGINT', async () => {
+    process.stderr.write('Shutting down...\n');
+    await app.close();
+    process.exit(0);
+  });
+}
+
+bootstrap().catch((err) => {
+  process.stderr.write(`Fatal error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/apps/example-sse-server/package.json
+++ b/apps/example-sse-server/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/apps/example-sse-server/package.json
+++ b/apps/example-sse-server/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/apps/example-stdio/package.json
+++ b/apps/example-stdio/package.json
@@ -20,7 +20,7 @@
     "@nestjs/core": "^11.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/apps/example-stdio/package.json
+++ b/apps/example-stdio/package.json
@@ -20,7 +20,7 @@
     "@nestjs/core": "^11.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@nestjs/testing": "^11.0.0",

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@nestjs/testing": "^11.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -48,13 +48,13 @@
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "reflect-metadata": ">=0.1.13",
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "reflect-metadata": "^0.2.0",
-    "zod": "^4.3.6",
+    "zod": "^4.0.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"
   }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -48,18 +48,13 @@
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "reflect-metadata": ">=0.1.13",
-    "zod": "^3.0.0"
-  },
-  "peerDependenciesMeta": {
-    "zod": {
-      "optional": true
-    }
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "reflect-metadata": "^0.2.0",
-    "zod": "^3.24.0",
+    "zod": "^4.3.6",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"
   }

--- a/packages/common/src/utils/schema-converter.spec.ts
+++ b/packages/common/src/utils/schema-converter.spec.ts
@@ -29,16 +29,16 @@ describe('zodToJsonSchema', () => {
     });
   });
 
-  it('should convert ZodString with email format', () => {
-    const schema = z.string().email();
-    expect(zodToJsonSchema(schema)).toEqual({
+  it('should convert email schema with format', () => {
+    const schema = z.email();
+    expect(zodToJsonSchema(schema)).toMatchObject({
       type: 'string',
       format: 'email',
     });
   });
 
-  it('should convert ZodString with url format', () => {
-    const schema = z.string().url();
+  it('should convert url schema with format', () => {
+    const schema = z.url();
     expect(zodToJsonSchema(schema)).toEqual({
       type: 'string',
       format: 'uri',
@@ -70,7 +70,7 @@ describe('zodToJsonSchema', () => {
 
   it('should convert ZodNumber with int check', () => {
     const schema = z.number().int();
-    expect(zodToJsonSchema(schema)).toEqual({ type: 'integer' });
+    expect(zodToJsonSchema(schema)).toMatchObject({ type: 'integer' });
   });
 
   it('should convert ZodBoolean to JSON Schema', () => {
@@ -103,6 +103,7 @@ describe('zodToJsonSchema', () => {
         age: { type: 'number' },
       },
       required: ['name', 'age'],
+      additionalProperties: false,
     });
   });
 
@@ -119,6 +120,7 @@ describe('zodToJsonSchema', () => {
         nickname: { type: 'string' },
       },
       required: ['name'],
+      additionalProperties: false,
     });
   });
 
@@ -161,11 +163,10 @@ describe('zodToJsonSchema', () => {
     });
   });
 
-  it('should convert ZodNullable to JSON Schema', () => {
+  it('should convert ZodNullable to JSON Schema anyOf', () => {
     const schema = z.string().nullable();
     expect(zodToJsonSchema(schema)).toEqual({
-      type: 'string',
-      nullable: true,
+      anyOf: [{ type: 'string' }, { type: 'null' }],
     });
   });
 
@@ -178,12 +179,12 @@ describe('zodToJsonSchema', () => {
 
   it('should convert ZodLiteral to JSON Schema const', () => {
     const schema = z.literal('hello');
-    expect(zodToJsonSchema(schema)).toEqual({ const: 'hello' });
+    expect(zodToJsonSchema(schema)).toMatchObject({ const: 'hello' });
   });
 
   it('should convert ZodRecord to JSON Schema', () => {
-    const schema = z.record(z.string());
-    expect(zodToJsonSchema(schema)).toEqual({
+    const schema = z.record(z.string(), z.string());
+    expect(zodToJsonSchema(schema)).toMatchObject({
       type: 'object',
       additionalProperties: { type: 'string' },
     });
@@ -204,10 +205,9 @@ describe('zodToJsonSchema', () => {
     expect(zodToJsonSchema(schema)).toEqual({ type: 'string' });
   });
 
-  it('should return empty object for unknown Zod types', () => {
-    // Craft a fake schema with an unknown typeName to hit the default case
-    const fakeSchema = { _def: { typeName: 'ZodUnknownType' } } as unknown as z.ZodType;
-    expect(zodToJsonSchema(fakeSchema)).toEqual({});
+  it('should not include $schema in the output', () => {
+    const schema = z.string();
+    expect(zodToJsonSchema(schema)).not.toHaveProperty('$schema');
   });
 });
 

--- a/packages/common/src/utils/schema-converter.ts
+++ b/packages/common/src/utils/schema-converter.ts
@@ -1,142 +1,14 @@
-import type { ZodType } from 'zod';
-
-// Zod _def internals have no public type definitions — we must use unknown and cast
-interface ZodDef {
-  typeName?: string;
-  description?: string;
-  checks?: Array<{ kind: string; value?: unknown; regex?: RegExp; inclusive?: boolean }>;
-  values?: string[];
-  value?: unknown;
-  type?: { _def?: ZodDef };
-  innerType?: { _def?: ZodDef };
-  options?: Array<{ _def?: ZodDef }>;
-  valueType?: { _def?: ZodDef };
-  shape?: () => Record<string, { _def?: ZodDef }>;
-  defaultValue?: () => unknown;
-}
+import { ZodObject, type ZodType, z } from 'zod';
 
 /**
  * Converts a Zod schema to JSON Schema compatible with MCP specification.
- * Uses zodToJsonSchema if available from zod, otherwise uses basic conversion.
+ * Uses Zod v4's native z.toJSONSchema() for accurate conversion.
  */
 export function zodToJsonSchema(schema: ZodType): Record<string, unknown> {
-  // Use Zod's built-in JSON Schema generation if available (Zod 3.x)
-  if ('_def' in schema) {
-    return convertZodDef((schema as unknown as { _def: ZodDef })._def);
-  }
-  return { type: 'object' };
-}
-
-function convertZodDef(def: ZodDef): Record<string, unknown> {
-  if (!def) return {};
-
-  const typeName = def.typeName;
-
-  switch (typeName) {
-    case 'ZodString':
-      return buildStringSchema(def);
-    case 'ZodNumber':
-      return buildNumberSchema(def);
-    case 'ZodBoolean':
-      return { type: 'boolean' };
-    case 'ZodNull':
-      return { type: 'null' };
-    case 'ZodArray':
-      return { type: 'array', items: convertZodDef(def.type?._def ?? {}) };
-    case 'ZodObject':
-      return buildObjectSchema(def);
-    case 'ZodEnum':
-      return { type: 'string', enum: def.values };
-    case 'ZodOptional':
-      return convertZodDef(def.innerType?._def ?? {});
-    case 'ZodDefault':
-      return {
-        ...convertZodDef(def.innerType?._def ?? {}),
-        default: def.defaultValue?.(),
-      };
-    case 'ZodNullable': {
-      const inner = convertZodDef(def.innerType?._def ?? {});
-      return { ...inner, nullable: true };
-    }
-    case 'ZodUnion':
-      return {
-        anyOf: def.options?.map((opt) => convertZodDef(opt._def ?? {})) ?? [],
-      };
-    case 'ZodLiteral':
-      return { const: def.value };
-    case 'ZodRecord':
-      return {
-        type: 'object',
-        additionalProperties: convertZodDef(def.valueType?._def ?? {}),
-      };
-    default:
-      return {};
-  }
-}
-
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: straightforward check-kind mapping
-function buildStringSchema(def: ZodDef): Record<string, unknown> {
-  const schema: Record<string, unknown> = { type: 'string' };
-  if (def.checks) {
-    for (const check of def.checks) {
-      if (check.kind === 'min') schema.minLength = check.value;
-      if (check.kind === 'max') schema.maxLength = check.value;
-      if (check.kind === 'regex') schema.pattern = check.regex?.source;
-      if (check.kind === 'email') schema.format = 'email';
-      if (check.kind === 'url') schema.format = 'uri';
-    }
-  }
-  return schema;
-}
-
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: straightforward check-kind mapping
-function buildNumberSchema(def: ZodDef): Record<string, unknown> {
-  const schema: Record<string, unknown> = { type: 'number' };
-  if (def.checks) {
-    for (const check of def.checks) {
-      if (check.kind === 'min') {
-        schema[check.inclusive ? 'minimum' : 'exclusiveMinimum'] = check.value;
-      }
-      if (check.kind === 'max') {
-        schema[check.inclusive ? 'maximum' : 'exclusiveMaximum'] = check.value;
-      }
-      if (check.kind === 'int') schema.type = 'integer';
-    }
-  }
-  return schema;
-}
-
-function buildObjectSchema(def: ZodDef): Record<string, unknown> {
-  const shape = def.shape?.();
-  if (!shape) return { type: 'object' };
-
-  const properties: Record<string, unknown> = {};
-  const required: string[] = [];
-
-  for (const [key, value] of Object.entries(shape)) {
-    const fieldDef = value?._def;
-    properties[key] = convertZodDef(fieldDef ?? {});
-
-    // Add description from .describe()
-    if (fieldDef?.description) {
-      (properties[key] as Record<string, unknown>).description = fieldDef.description;
-    }
-
-    // Check if field is optional
-    if (fieldDef?.typeName !== 'ZodOptional' && fieldDef?.typeName !== 'ZodDefault') {
-      required.push(key);
-    }
-  }
-
-  const schema: Record<string, unknown> = { type: 'object', properties };
-  if (required.length > 0) schema.required = required;
-
-  // Add description from .describe()
-  if (def.description) {
-    schema.description = def.description;
-  }
-
-  return schema;
+  const result = z.toJSONSchema(schema) as Record<string, unknown>;
+  // Strip $schema metadata — not needed for MCP tool/resource schemas
+  delete result.$schema;
+  return result;
 }
 
 /**
@@ -145,20 +17,14 @@ function buildObjectSchema(def: ZodDef): Record<string, unknown> {
  * Intended to be called during tool/prompt registration for dev-time feedback.
  */
 export function warnMissingDescriptions(schema: ZodType, label: string): void {
-  const def = (schema as unknown as { _def?: ZodDef })?._def;
-  if (!def) return;
-
-  if (!def.description) {
+  if (!z.globalRegistry.get(schema)?.description) {
     console.warn(`[nest-mcp] ${label}: schema is missing a top-level .describe() call`);
   }
 
-  if (def.typeName === 'ZodObject') {
-    const shape = def.shape?.();
-    if (shape) {
-      for (const [key, value] of Object.entries(shape)) {
-        if (!value?._def?.description) {
-          console.warn(`[nest-mcp] ${label}: field '${key}' is missing a .describe() call`);
-        }
+  if (schema instanceof ZodObject) {
+    for (const [key, field] of Object.entries(schema.shape)) {
+      if (!z.globalRegistry.get(field as ZodType)?.description) {
+        console.warn(`[nest-mcp] ${label}: field '${key}' is missing a .describe() call`);
       }
     }
   }
@@ -170,20 +36,16 @@ export function warnMissingDescriptions(schema: ZodType, label: string): void {
 export function extractZodDescriptions(
   schema: ZodType,
 ): Array<{ name: string; description?: string; required: boolean }> {
-  const def = (schema as unknown as { _def?: ZodDef })?._def;
-  if (def?.typeName !== 'ZodObject') return [];
-
-  const shape = def.shape?.();
-  if (!shape) return [];
+  if (!(schema instanceof ZodObject)) return [];
 
   const result: Array<{ name: string; description?: string; required: boolean }> = [];
 
-  for (const [key, value] of Object.entries(shape)) {
-    const fieldDef = value?._def;
+  for (const [key, field] of Object.entries(schema.shape)) {
+    const zodField = field as ZodType;
     result.push({
       name: key,
-      description: fieldDef?.description,
-      required: fieldDef?.typeName !== 'ZodOptional' && fieldDef?.typeName !== 'ZodDefault',
+      description: z.globalRegistry.get(zodField)?.description,
+      required: !zodField.isOptional(),
     });
   }
 

--- a/packages/common/src/utils/schema-converter.ts
+++ b/packages/common/src/utils/schema-converter.ts
@@ -5,9 +5,8 @@ import { ZodObject, type ZodType, z } from 'zod';
  * Uses Zod v4's native z.toJSONSchema() for accurate conversion.
  */
 export function zodToJsonSchema(schema: ZodType): Record<string, unknown> {
-  const result = z.toJSONSchema(schema) as Record<string, unknown>;
   // Strip $schema metadata — not needed for MCP tool/resource schemas
-  delete result.$schema;
+  const { $schema: _$schema, ...result } = z.toJSONSchema(schema) as Record<string, unknown>;
   return result;
 }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -63,7 +63,7 @@
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "reflect-metadata": ">=0.1.13",
     "rxjs": "^7.0.0",
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.10.0",
@@ -77,6 +77,6 @@
     "rxjs": "^7.8.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0",
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -63,7 +63,7 @@
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "reflect-metadata": ">=0.1.13",
     "rxjs": "^7.0.0",
-    "zod": "^3.0.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.10.0",
@@ -77,6 +77,6 @@
     "rxjs": "^7.8.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   }
 }

--- a/packages/server/src/execution/executor.service.ts
+++ b/packages/server/src/execution/executor.service.ts
@@ -16,7 +16,7 @@ import {
   zodToJsonSchema,
 } from '@nest-mcp/common';
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import type { ZodType } from 'zod';
+import { ZodEnum, ZodObject, type ZodType } from 'zod';
 import { McpRegistryService } from '../discovery/registry.service';
 import type { RegisteredTool } from '../discovery/registry.service';
 
@@ -286,23 +286,16 @@ export class McpExecutorService {
     const prompt = this.registry.getPrompt(promptName);
     if (!prompt?.parameters) return { values: [] };
 
-    const def = (
-      prompt.parameters as unknown as {
-        _def?: {
-          shape?: () => Record<string, { _def?: { typeName?: string; values?: string[] } }>;
-        };
-      }
-    )?._def;
-    const shape = def?.shape?.();
-    if (!shape) return { values: [] };
+    if (!(prompt.parameters instanceof ZodObject)) return { values: [] };
+    const shape = prompt.parameters.shape;
 
-    const field = shape[argument.name];
-    if (!field?._def) return { values: [] };
+    const field = shape[argument.name] as ZodType | undefined;
+    if (!field) return { values: [] };
 
     // Support ZodEnum fields: filter values by prefix
-    if (field._def.typeName === 'ZodEnum' && Array.isArray(field._def.values)) {
+    if (field instanceof ZodEnum) {
       const prefix = argument.value.toLowerCase();
-      const filtered = (field._def.values as string[]).filter((v) =>
+      const filtered = (field.options as string[]).filter((v) =>
         v.toLowerCase().startsWith(prefix),
       );
       return this.normalizeCompletionResult({ values: filtered });

--- a/packages/server/src/transport/register-handlers.ts
+++ b/packages/server/src/transport/register-handlers.ts
@@ -39,7 +39,7 @@ import type { ResourceSubscriptionManager } from '../subscription/resource-subsc
  * tools (e.g. gateway-proxied tools) that only have JSON schemas, not Zod schemas.
  * The MCP SDK requires a Zod schema to pass arguments to the handler callback.
  */
-const PASSTHROUGH_SCHEMA = z.object({}).passthrough();
+const PASSTHROUGH_SCHEMA = z.looseObject({});
 
 /**
  * Map of active request IDs to their AbortControllers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,18 +35,18 @@ importers:
 
   apps/example-browser-mcp:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.10.0
+        version: 1.26.0(zod@4.3.6)
+      '@mozilla/readability':
+        specifier: ^0.5.0
+        version: 0.5.0
       '@nest-mcp/common':
         specifier: workspace:*
         version: link:../../packages/common
       '@nest-mcp/server':
         specifier: workspace:*
         version: link:../../packages/server
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
-      '@mozilla/readability':
-        specifier: ^0.5.0
-        version: 0.5.0
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -75,8 +75,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@types/jsdom':
         specifier: ^21.1.6
@@ -90,15 +90,15 @@ importers:
 
   apps/example-client:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.10.0
+        version: 1.26.0(zod@4.3.6)
       '@nest-mcp/client':
         specifier: workspace:*
         version: link:../../packages/client
       '@nest-mcp/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -127,6 +127,9 @@ importers:
 
   apps/example-gateway:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.10.0
+        version: 1.26.0(zod@4.3.6)
       '@nest-mcp/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -136,9 +139,6 @@ importers:
       '@nest-mcp/server':
         specifier: workspace:*
         version: link:../../packages/server
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -164,15 +164,15 @@ importers:
 
   apps/example-postgres-mcp:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.10.0
+        version: 1.26.0(zod@4.3.6)
       '@nest-mcp/common':
         specifier: workspace:*
         version: link:../../packages/common
       '@nest-mcp/server':
         specifier: workspace:*
         version: link:../../packages/server
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -192,8 +192,8 @@ importers:
         specifier: ^7.8.0
         version: 7.8.2
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@types/pg':
         specifier: ^8.11.0
@@ -204,15 +204,15 @@ importers:
 
   apps/example-sse-server:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.10.0
+        version: 1.26.0(zod@4.3.6)
       '@nest-mcp/common':
         specifier: workspace:*
         version: link:../../packages/common
       '@nest-mcp/server':
         specifier: workspace:*
         version: link:../../packages/server
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -232,8 +232,8 @@ importers:
         specifier: ^7.8.0
         version: 7.8.2
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -241,15 +241,15 @@ importers:
 
   apps/example-stdio:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.10.0
+        version: 1.26.0(zod@4.3.6)
       '@nest-mcp/common':
         specifier: workspace:*
         version: link:../../packages/common
       '@nest-mcp/server':
         specifier: workspace:*
         version: link:../../packages/server
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -263,8 +263,8 @@ importers:
         specifier: ^7.8.0
         version: 7.8.2
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -272,15 +272,15 @@ importers:
 
   apps/playground:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.10.0
+        version: 1.26.0(zod@4.3.6)
       '@nest-mcp/common':
         specifier: workspace:*
         version: link:../../packages/common
       '@nest-mcp/server':
         specifier: workspace:*
         version: link:../../packages/server
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -297,8 +297,8 @@ importers:
         specifier: ^7.8.0
         version: 7.8.2
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@nestjs/testing':
         specifier: ^11.0.0
@@ -315,7 +315,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
+        version: 1.26.0(zod@4.3.6)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -356,8 +356,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.11)(jsdom@24.1.3)
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
 
   packages/gateway:
     dependencies:
@@ -373,7 +373,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
+        version: 1.26.0(zod@4.3.6)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -410,7 +410,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.10.0
-        version: 1.26.0(zod@3.25.76)
+        version: 1.26.0(zod@4.3.6)
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -442,8 +442,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.11)(jsdom@24.1.3)
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
 
 packages:
 
@@ -2657,8 +2657,8 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -3065,7 +3065,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.1)
       ajv: 8.18.0
@@ -3082,8 +3082,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -4806,8 +4806,8 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
-  zod@3.25.76: {}
+  zod@4.3.6: {}


### PR DESCRIPTION
- Bump zod peer/dev deps to ^4.3.6 in all packages and apps
- Rewrite schema-converter.ts using z.toJSONSchema() and z.globalRegistry
- Fix register-handlers.ts: z.object({}).passthrough() → z.looseObject({})
- Fix executor.service.ts: replace _def introspection with instanceof ZodObject/ZodEnum
- Add stdio entry point to example-postgres-mcp (app-stdio.module.ts, main.stdio.ts)
- Update schema-converter.spec.ts for Zod v4 JSON Schema output