### PR TITLE
docs: add zod@^4 to installation commands in package READMEs

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -10,7 +10,7 @@ NestJS module for connecting to and consuming [Model Context Protocol (MCP)](htt
 ## Installation
 
 ```bash
-npm install @nest-mcp/client @modelcontextprotocol/sdk
+npm install @nest-mcp/client @modelcontextprotocol/sdk zod@^4
 npm install @nestjs/common @nestjs/core reflect-metadata rxjs
 ```
 

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -10,7 +10,7 @@ NestJS module for aggregating multiple upstream [MCP](https://modelcontextprotoc
 ## Installation
 
 ```bash
-npm install @nest-mcp/gateway @modelcontextprotocol/sdk
+npm install @nest-mcp/gateway @modelcontextprotocol/sdk zod@^4
 npm install @nestjs/common @nestjs/core reflect-metadata rxjs
 ```
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -10,7 +10,7 @@ NestJS module for building [Model Context Protocol (MCP)](https://modelcontextpr
 ## Installation
 
 ```bash
-npm install @nest-mcp/server @modelcontextprotocol/sdk
+npm install @nest-mcp/server @modelcontextprotocol/sdk zod@^4
 npm install @nestjs/common @nestjs/core reflect-metadata rxjs
 ```
 


### PR DESCRIPTION
Mirror the root README fix: move `zod@^4` next to `@modelcontextprotocol/sdk` in server, client, and gateway package READMEs.