### PR TITLE
feat(server): add imports option to McpModule.forFeature()

### DIFF
--- a/docs/server/module.md
+++ b/docs/server/module.md
@@ -144,10 +144,44 @@ import { WeatherTools } from './weather-tools.service';
 export class WeatherModule {}
 ```
 
+With an options object, you can import modules that export providers needed by the feature's tools:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { McpModule } from '@nest-mcp/server';
+import { HttpModule } from '@nestjs/axios';
+import { WeatherTools } from './weather-tools.service';
+
+@Module({
+  imports: [
+    McpModule.forFeature([WeatherTools], {
+      imports: [HttpModule],
+    }),
+  ],
+})
+export class WeatherModule {}
+```
+
+### McpForFeatureOptions
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `imports` | `any[]` | No | Modules that export providers needed by the feature's tools |
+| `serverName` | `string` | No | Server name to scope providers to a specific server instance |
+
 With a `serverName` parameter, providers are scoped to a specific server instance:
 
 ```typescript
 McpModule.forFeature([WeatherTools], 'weather-server');
+```
+
+You can also combine both options:
+
+```typescript
+McpModule.forFeature([WeatherTools], {
+  imports: [HttpModule],
+  serverName: 'weather-server',
+});
 ```
 
 ## Global Module

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,7 @@
 
 // Module
 export { McpModule } from './mcp.module';
+export type { McpForFeatureOptions } from './mcp.module';
 
 // Decorators
 export {

--- a/packages/server/src/mcp.module.spec.ts
+++ b/packages/server/src/mcp.module.spec.ts
@@ -227,6 +227,71 @@ describe('McpModule', () => {
       expect(mod.module).toBe(McpModule);
     });
 
+    describe('with options object', () => {
+      it('includes imports in returned module without serverName', () => {
+        class FakeProvider {}
+        class FakeImportModule {}
+        const mod = McpModule.forFeature([FakeProvider], { imports: [FakeImportModule] });
+
+        expect(mod.module).toBe(McpModule);
+        expect(mod.imports).toContain(FakeImportModule);
+        expect(mod.providers).toContain(FakeProvider);
+        expect(mod.exports).toContain(FakeProvider);
+      });
+
+      it('defaults imports to empty array when options object has no imports', () => {
+        class FakeProvider {}
+        const mod = McpModule.forFeature([FakeProvider], {});
+
+        expect(mod.module).toBe(McpModule);
+        expect(mod.imports).toEqual([]);
+      });
+
+      it('includes imports with serverName using McpFeatureModule', async () => {
+        const { McpFeatureModule } = await import('./discovery/mcp-feature.module');
+        class FakeProvider {}
+        class FakeImportModule {}
+        const mod = McpModule.forFeature([FakeProvider], {
+          imports: [FakeImportModule],
+          serverName: 'my-server',
+        });
+
+        expect(mod.module).toBe(McpFeatureModule);
+        expect(mod.imports).toContain(FakeImportModule);
+        expect(mod.global).toBe(true);
+      });
+
+      it('creates registration token when serverName is provided via options', () => {
+        class FakeProvider {}
+        const mod = McpModule.forFeature([FakeProvider], {
+          serverName: 'target-server',
+          imports: [],
+        });
+        const registrationProvider = (
+          mod.providers as { provide: string; useValue: unknown }[]
+        ).find(
+          (p) => typeof p.provide === 'string' && p.provide.startsWith('MCP_FEATURE_REGISTRATION_'),
+        );
+        expect(registrationProvider).toBeDefined();
+        expect(registrationProvider?.useValue).toMatchObject({
+          serverName: 'target-server',
+          providerTokens: [FakeProvider],
+        });
+      });
+
+      it('passes through multiple imports', () => {
+        class FakeProvider {}
+        class ModuleA {}
+        class ModuleB {}
+        class ModuleC {}
+        const mod = McpModule.forFeature([FakeProvider], {
+          imports: [ModuleA, ModuleB, ModuleC],
+        });
+
+        expect(mod.imports).toEqual([ModuleA, ModuleB, ModuleC]);
+      });
+    });
+
     describe('with serverName (named-server targeting)', () => {
       it('uses McpFeatureModule instead of McpModule', async () => {
         const { McpFeatureModule } = await import('./discovery/mcp-feature.module');

--- a/packages/server/src/mcp.module.ts
+++ b/packages/server/src/mcp.module.ts
@@ -9,6 +9,14 @@ import {
   type Type,
 } from '@nestjs/common';
 
+export interface McpForFeatureOptions {
+  /** Modules to import that export providers needed by the feature's tools. */
+  // biome-ignore lint/suspicious/noExplicitAny: NestJS ModuleMetadata uses any[]
+  imports?: any[];
+  /** Server name to scope providers to a specific server instance. */
+  serverName?: string;
+}
+
 import {
   type McpFeatureRegistration,
   nextFeatureRegistrationToken,
@@ -221,17 +229,33 @@ export class McpModule {
     };
   }
 
-  static forFeature(providers: Type[], serverName?: string): DynamicModule {
-    if (!serverName) {
-      // Backward-compatible: no server targeting
-      return { module: McpModule, providers, exports: providers };
+  static forFeature(providers: Type[]): DynamicModule;
+  static forFeature(providers: Type[], serverName: string): DynamicModule;
+  static forFeature(providers: Type[], options: McpForFeatureOptions): DynamicModule;
+  static forFeature(
+    providers: Type[],
+    serverNameOrOptions?: string | McpForFeatureOptions,
+  ): DynamicModule {
+    const opts: McpForFeatureOptions =
+      typeof serverNameOrOptions === 'string'
+        ? { serverName: serverNameOrOptions }
+        : (serverNameOrOptions ?? {});
+
+    const imports = opts.imports ?? [];
+
+    if (!opts.serverName) {
+      return { module: McpModule, imports, providers, exports: providers };
     }
 
-    const registration: McpFeatureRegistration = { serverName, providerTokens: providers };
+    const registration: McpFeatureRegistration = {
+      serverName: opts.serverName,
+      providerTokens: providers,
+    };
     const registrationToken = nextFeatureRegistrationToken();
 
     return {
       module: McpFeatureModule,
+      imports,
       providers: [...providers, { provide: registrationToken, useValue: registration }],
       exports: [...providers, registrationToken],
       global: true,


### PR DESCRIPTION
## Summary
- Add `McpForFeatureOptions` interface with `imports` and `serverName` fields
- Overload `forFeature()` to accept an options object alongside the existing string signature
- Export `McpForFeatureOptions` type from `@nest-mcp/server`
- Update docs with usage examples and options table

## Test plan
- [x] 5 new tests covering options object with/without serverName, empty defaults, multiple imports
- [x] All 823 existing server tests pass
- [x] Build passes across all packages
- [x] Lint passes (biome format + rules)