### PR TITLE
chore: add changeset for forFeature imports option

### DIFF
--- a/.changeset/for-feature-imports.md
+++ b/.changeset/for-feature-imports.md
@@ -1,0 +1,5 @@
+---
+'@nest-mcp/server': minor
+---
+
+Add `imports` option to `McpModule.forFeature()` allowing feature modules to import other modules that export providers needed by the feature's tools.


### PR DESCRIPTION
Adds the missing changeset for the `McpModule.forFeature()` imports feature (PR #15) to trigger a minor release of `@nest-mcp/server`.