### PR TITLE
fix(client): guard notification wiring against non-function prototype props

### DIFF
--- a/.changeset/fix-client-bootstrap-non-function-prototype.md
+++ b/.changeset/fix-client-bootstrap-non-function-prototype.md
@@ -1,0 +1,5 @@
+---
+'@nest-mcp/client': patch
+---
+
+Fix `McpClientBootstrap.wireNotificationHandlers` crashing with `TypeError` when a sibling provider's prototype exposes non-function own properties (e.g. `useValue: {}` providers, whose prototype `Object.prototype.__proto__` resolves to `null`). The notification scan now skips prototype entries whose value is not a function before calling `Reflect.getMetadata`. Fixes #18.

--- a/packages/client/src/mcp-client.module.spec.ts
+++ b/packages/client/src/mcp-client.module.spec.ts
@@ -467,4 +467,56 @@ describe('McpClientBootstrap notification wiring', () => {
 
     expect(onNotificationFn).not.toHaveBeenCalled();
   });
+
+  it('skips non-function prototype own properties without throwing', async () => {
+    const onNotificationFn = vi.fn();
+    const clientA = {
+      name: 'server-a',
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      isConnected: vi.fn().mockReturnValue(true),
+      onNotification: onNotificationFn,
+    } as unknown as McpClient;
+
+    // Simulates providers registered with `useValue: {}` (plain object) or
+    // classes whose prototype exposes non-function own properties via
+    // accessors — `Reflect.getMetadata` throws TypeError on non-object targets.
+    class HandlerWithAccessor {
+      handleNotification() {}
+    }
+    Object.defineProperty(HandlerWithAccessor.prototype, 'nonFunctionProp', {
+      get() {
+        return null;
+      },
+      enumerable: false,
+      configurable: true,
+    });
+    Object.defineProperty(HandlerWithAccessor.prototype, 'primitiveProp', {
+      value: 42,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    const handlerInstance = new HandlerWithAccessor();
+    Reflect.defineMetadata(
+      MCP_NOTIFICATION_METADATA,
+      { connectionName: 'server-a', method: 'notifications/tools/list_changed' },
+      HandlerWithAccessor.prototype.handleNotification,
+    );
+
+    const plainValueProvider = {};
+
+    const modulesContainer = createMockModulesContainer([
+      { instance: plainValueProvider },
+      { instance: handlerInstance },
+    ]);
+
+    const boot = new McpClientBootstrap([clientA], modulesContainer);
+    await expect(boot.onApplicationBootstrap()).resolves.toBeUndefined();
+
+    expect(onNotificationFn).toHaveBeenCalledWith(
+      'notifications/tools/list_changed',
+      expect.any(Function),
+    );
+  });
 });

--- a/packages/client/src/mcp-client.module.ts
+++ b/packages/client/src/mcp-client.module.ts
@@ -184,12 +184,19 @@ export class McpClientBootstrap implements OnApplicationBootstrap, OnApplication
         );
 
         for (const methodName of methodNames) {
+          // Prototype own-property names can include non-function values
+          // (e.g. `Object.prototype.__proto__` on `useValue: {}` providers, or
+          // accessor properties on library classes). `Reflect.getMetadata`
+          // throws TypeError on non-object targets, so skip non-functions.
+          const method = prototype[methodName];
+          if (typeof method !== 'function') continue;
+
           // NestJS SetMetadata stores metadata on the descriptor.value (the method
-          // function itself), so we read from prototype[methodName] rather than
-          // using the (target, propertyKey) overload.
+          // function itself), so we read from the method rather than using the
+          // (target, propertyKey) overload.
           const metadata: McpNotificationMetadata | undefined = Reflect.getMetadata(
             MCP_NOTIFICATION_METADATA,
-            prototype[methodName],
+            method,
           );
 
           if (!metadata) continue;


### PR DESCRIPTION
## Summary
- Fixes #18 — `McpClientBootstrap.wireNotificationHandlers` throwing `TypeError` when any provider in the DI graph has a prototype whose `getOwnPropertyNames` list includes a non-function value (e.g. `useValue: {}` providers, whose prototype is `Object.prototype` and `Object.prototype.__proto__` resolves to `null`).
- Adds a `typeof method !== 'function'` guard before the `Reflect.getMetadata` call, hoisting `prototype[methodName]` into a local.
- Adds a regression test that seeds a plain-object provider alongside a handler whose prototype carries both a getter returning `null` and a primitive data property, asserting bootstrap resolves and the real handler still wires.

## Test plan
- [x] `cd packages/client && pnpm test` — 202/202 pass (new test + 201 existing)
- [x] New test fails with the exact `TypeError` at `Reflect.js:367` from `wireNotificationHandlers` before the guard is applied