### PR TITLE
feat: tool exposure / discovery-strategy config

### DIFF
--- a/.changeset/tool-exposure-strategy.md
+++ b/.changeset/tool-exposure-strategy.md
@@ -16,6 +16,7 @@ Also ships:
 
 - `clientSupports.search(ctx)` capability helper (checks the `advanced-tool-use-2025-11-20` beta header — no model regex required in user code).
 - `preferSearchElseLazy({ eager })` preset resolver for the common per-client tiering case.
+- `defineResolver([...kinds], fn)` to declare which strategy kinds a custom resolver can produce. `ExposureService` uses this declaration to skip conservative meta-tool registration when `lazy` is not reachable.
 - `buildClientContext({ transport, request, clientInfo, model })` helper that parses `anthropic-beta` headers into `ClientContext`.
 - `@Tool({ ..., tags, exposure })` decorator fields. `tags` feeds selectors like `eager: { tags: ['core'] }`; `exposure: 'eager' | 'deferred' | 'auto'` overrides module policy per tool.
 

--- a/.changeset/tool-exposure-strategy.md
+++ b/.changeset/tool-exposure-strategy.md
@@ -1,0 +1,22 @@
+---
+'@nest-mcp/common': minor
+'@nest-mcp/server': minor
+---
+
+Add tool exposure / discovery-strategy configuration. Large tool catalogs can now avoid bloating the initial prompt by deferring schemas until they are needed.
+
+Configure via `McpModuleOptions.exposure` with a static strategy or a per-client resolver:
+
+- `{ kind: 'eager' }` — current behaviour, full schemas in `tools/list`.
+- `{ kind: 'search', variant: 'bm25' | 'regex', eager?, onAllDeferred? }` — annotates deferred tools with `_meta.defer_loading: true` for Anthropic's Tool Search Tool beta.
+- `{ kind: 'lazy', eager?, indexToolName?, schemaToolName?, maxBatchSize?, requireDiscovery? }` — vendor-neutral: ships `list_available_tools` and `get_tool_schema` meta-tools so clients pull definitions on demand.
+- `{ kind: 'typed-api' }` — reserved for Code Mode; throws at runtime in this release.
+
+Also ships:
+
+- `clientSupports.search(ctx)` capability helper (checks the `advanced-tool-use-2025-11-20` beta header — no model regex required in user code).
+- `preferSearchElseLazy({ eager })` preset resolver for the common per-client tiering case.
+- `buildClientContext({ transport, request, clientInfo, model })` helper that parses `anthropic-beta` headers into `ClientContext`.
+- `@Tool({ ..., tags, exposure })` decorator fields. `tags` feeds selectors like `eager: { tags: ['core'] }`; `exposure: 'eager' | 'deferred' | 'auto'` overrides module policy per tool.
+
+All new fields are optional; existing servers continue to behave as before. No protocol extensions — both the `search` annotations and the `lazy` meta-tools work over plain MCP JSON-RPC.

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,6 +20,7 @@ export * from './interfaces/http-adapter.interface';
 export * from './interfaces/mcp-completion.interface';
 export * from './interfaces/mcp-elicitation.interface';
 export * from './interfaces/mcp-sampling.interface';
+export * from './interfaces/mcp-exposure.interface';
 
 // Types
 export * from './types/json-rpc.types';
@@ -45,6 +46,9 @@ export * from './utils/capabilities-builder';
 export * from './utils/duration';
 export { paginate, type PaginatedResult } from './utils/paginator';
 export { drainAllPages } from './utils/drain-pages';
+export * from './utils/exposure-capabilities';
+export * from './utils/exposure-presets';
+export * from './utils/build-client-context';
 
 // Decorators
 export * from './decorators/metadata.utils';

--- a/packages/common/src/interfaces/mcp-exposure.interface.ts
+++ b/packages/common/src/interfaces/mcp-exposure.interface.ts
@@ -79,10 +79,26 @@ export interface ClientContext {
 }
 
 /**
+ * Symbol-keyed marker for attaching "which kinds can this resolver return?"
+ * metadata to a resolver function. Set by {@link defineResolver} and read by
+ * `ExposureService` at bootstrap to avoid conservative meta-tool registration.
+ *
+ * Kept as a module-local Symbol (not `Symbol.for`) so there's no cross-realm
+ * collision risk and no accidental key-name overlap on user-supplied functions.
+ */
+export const RESOLVER_KINDS: unique symbol = Symbol('@nest-mcp/exposure.resolver.kinds');
+
+/**
  * Either a plain strategy or a function that picks one from client context.
  * The function form is how per-client tiering is expressed.
+ *
+ * When the function form is used, wrap with {@link defineResolver} to declare
+ * which strategy kinds it can produce. Without that declaration, the service
+ * falls back to conservative meta-tool registration.
  */
-export type ExposureStrategyResolver = (ctx: ClientContext) => ExposureStrategy;
+export type ExposureStrategyResolver = ((ctx: ClientContext) => ExposureStrategy) & {
+  readonly [RESOLVER_KINDS]?: ReadonlyArray<ExposureStrategy['kind']>;
+};
 
 /** Shape carried in `_meta.defer_loading` on deferred tool entries for `kind: 'search'`. */
 export const META_DEFER_LOADING = 'defer_loading' as const;

--- a/packages/common/src/interfaces/mcp-exposure.interface.ts
+++ b/packages/common/src/interfaces/mcp-exposure.interface.ts
@@ -1,0 +1,88 @@
+import type { ToolMetadata } from './mcp-tool.interface';
+import type { McpTransportType } from './mcp-transport.interface';
+
+/**
+ * Per-tool exposure override carried in tool decorator metadata.
+ * Precedence: decorator > module strategy.
+ * - `eager`    — always surface the full schema in `tools/list`.
+ * - `deferred` — never surface the full schema; only reachable via the strategy-specific meta-tool.
+ * - `auto`     — follow the module-level strategy (default).
+ */
+export type ToolExposure = 'eager' | 'deferred' | 'auto';
+
+/**
+ * A selector describes which tools are the "eager" subset under a strategy that
+ * defers the long tail. All three forms are supported:
+ * - list of exact tool names
+ * - list of tags to match (inclusive OR)
+ * - arbitrary predicate over tool metadata
+ */
+export type ToolSelector = string[] | { tags: string[] } | ((meta: ToolMetadata) => boolean);
+
+export interface SearchStrategyOptions {
+  kind: 'search';
+  /** Anthropic Tool Search Tool variant. See the beta spec for details. */
+  variant: 'regex' | 'bm25';
+  eager?: ToolSelector;
+  /** Behaviour when no tool resolves to eager. `throw` is the safe default. */
+  onAllDeferred?: 'throw' | 'promoteFirst' | 'warn';
+}
+
+export interface LazyStrategyOptions {
+  kind: 'lazy';
+  eager?: ToolSelector;
+  /** Name of the index meta-tool. Default: `list_available_tools`. */
+  indexToolName?: string;
+  /** Name of the schema-fetch meta-tool. Default: `get_tool_schema`. */
+  schemaToolName?: string;
+  /** Fields included in the index response. Default: name, description, tags. */
+  indexFields?: Array<'name' | 'description' | 'tags'>;
+  /** Maximum batch size for `get_tool_schema`. Default: 20. */
+  maxBatchSize?: number;
+  /**
+   * When true, `tools/call` on a deferred tool whose schema has not been
+   * fetched in this session is rejected. Default: false (advisory only).
+   */
+  requireDiscovery?: boolean;
+}
+
+export interface TypedApiStrategyOptions {
+  kind: 'typed-api';
+  eager?: ToolSelector;
+  apiName?: string;
+}
+
+/**
+ * Catalog-presentation strategy. Applied to `tools/list` responses; does not
+ * change how `tools/call` executes.
+ *
+ * See `@nest-mcp/common` exposure-presets for the recommended factories.
+ */
+export type ExposureStrategy =
+  | { kind: 'eager' }
+  | SearchStrategyOptions
+  | LazyStrategyOptions
+  | TypedApiStrategyOptions;
+
+/**
+ * Minimal context a resolver sees when picking a strategy for an incoming
+ * client. Populated by the transport layer before `tools/list` is handled.
+ */
+export interface ClientContext {
+  /** MCP `clientInfo` from InitializeRequest, if known. */
+  clientInfo?: { name: string; version: string };
+  /** Model identifier if surfaced by the transport (best-effort, often absent). */
+  model?: string;
+  /** Values parsed from the `anthropic-beta` request header. */
+  betaHeaders?: string[];
+  transport: McpTransportType;
+}
+
+/**
+ * Either a plain strategy or a function that picks one from client context.
+ * The function form is how per-client tiering is expressed.
+ */
+export type ExposureStrategyResolver = (ctx: ClientContext) => ExposureStrategy;
+
+/** Shape carried in `_meta.defer_loading` on deferred tool entries for `kind: 'search'`. */
+export const META_DEFER_LOADING = 'defer_loading' as const;

--- a/packages/common/src/interfaces/mcp-options.interface.ts
+++ b/packages/common/src/interfaces/mcp-options.interface.ts
@@ -1,5 +1,6 @@
 import type { LogLevel } from '@nestjs/common';
 import type { McpGuardClass } from './mcp-auth.interface';
+import type { ExposureStrategy, ExposureStrategyResolver } from './mcp-exposure.interface';
 import type { McpMiddleware } from './mcp-middleware.interface';
 import type {
   CircuitBreakerConfig,
@@ -70,6 +71,14 @@ export interface McpModuleOptions {
     /** Vendor-specific experimental capability flags passed verbatim to the SDK. */
     experimental?: Record<string, unknown>;
   };
+
+  /**
+   * Catalog-presentation strategy. Controls how `tools/list` surfaces tools
+   * to clients (eager, deferred behind a search meta-tool, or on-demand via
+   * a lazy index). Per-client tiering is expressed by passing a resolver
+   * function instead of a static strategy. Defaults to `{ kind: 'eager' }`.
+   */
+  exposure?: ExposureStrategy | ExposureStrategyResolver;
 }
 
 export interface McpModuleAsyncOptions {

--- a/packages/common/src/interfaces/mcp-prompt.interface.ts
+++ b/packages/common/src/interfaces/mcp-prompt.interface.ts
@@ -20,7 +20,7 @@ export interface PromptMetadata {
   icons?: Icon[];
   _meta?: Record<string, unknown>;
   methodName: string;
-  target: abstract new (...args: unknown[]) => unknown;
+  target: abstract new (...args: never[]) => unknown;
 }
 
 export interface PromptArgument {

--- a/packages/common/src/interfaces/mcp-resource.interface.ts
+++ b/packages/common/src/interfaces/mcp-resource.interface.ts
@@ -21,7 +21,7 @@ export interface ResourceMetadata {
   icons?: Icon[];
   _meta?: Record<string, unknown>;
   methodName: string;
-  target: abstract new (...args: unknown[]) => unknown;
+  target: abstract new (...args: never[]) => unknown;
 }
 
 export interface ResourceTemplateOptions {
@@ -45,7 +45,7 @@ export interface ResourceTemplateMetadata {
   icons?: Icon[];
   _meta?: Record<string, unknown>;
   methodName: string;
-  target: abstract new (...args: unknown[]) => unknown;
+  target: abstract new (...args: never[]) => unknown;
 }
 
 export interface ResourceContent {

--- a/packages/common/src/interfaces/mcp-tool.interface.ts
+++ b/packages/common/src/interfaces/mcp-tool.interface.ts
@@ -1,5 +1,6 @@
 import type { ZodType } from 'zod';
 import type { McpGuardClass } from './mcp-auth.interface';
+import type { ToolExposure } from './mcp-exposure.interface';
 import type { McpMiddleware } from './mcp-middleware.interface';
 import type {
   CircuitBreakerConfig,
@@ -39,6 +40,18 @@ export interface ToolOptions {
   icons?: Icon[];
   execution?: ToolExecution;
   _meta?: Record<string, unknown>;
+  /**
+   * Free-form labels used by selectors in {@link ExposureStrategy} (e.g.
+   * `eager: { tags: ['core'] }`). Not transmitted over the wire.
+   */
+  tags?: string[];
+  /**
+   * Per-tool override for catalog presentation:
+   * - `eager` keeps this tool's full schema in `tools/list` even when the module defers the rest.
+   * - `deferred` removes this tool from the initial `tools/list` regardless of module strategy.
+   * - `auto` (default) follows the module strategy.
+   */
+  exposure?: ToolExposure;
 }
 
 export interface ToolMetadata {
@@ -67,6 +80,9 @@ export interface ToolMetadata {
   circuitBreaker?: CircuitBreakerConfig;
   // Middleware
   middleware?: McpMiddleware[];
+  // Exposure
+  tags?: string[];
+  exposure?: ToolExposure;
   // Internal
   methodName: string;
   target: abstract new (...args: unknown[]) => unknown;

--- a/packages/common/src/interfaces/mcp-tool.interface.ts
+++ b/packages/common/src/interfaces/mcp-tool.interface.ts
@@ -85,7 +85,36 @@ export interface ToolMetadata {
   exposure?: ToolExposure;
   // Internal
   methodName: string;
-  target: abstract new (...args: unknown[]) => unknown;
+  /**
+   * The class whose prototype carried the decorator. Uses `never[]` in the
+   * parameter position so ANY concrete constructor is assignable without
+   * `as unknown as` laundering (see Matt Pocock's "universal constructor
+   * type" pattern — `never` is the bottom type, assignable to any specific
+   * parameter list under strict function-type checking).
+   */
+  target: abstract new (
+    ...args: never[]
+  ) => unknown;
+}
+
+/**
+ * Shape of a single entry in the `tools/list` response, per the MCP spec.
+ *
+ * Produced by the executor's `buildToolEntries()` method and transformed
+ * by `ExposureService.applyStrategy()` before pagination. Using a typed
+ * shape (rather than `Record<string, unknown>`) lets every downstream
+ * consumer read `entry.name`, `entry._meta`, etc. without casts.
+ */
+export interface ToolListEntry {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  annotations?: ToolAnnotations;
+  icons?: Icon[];
+  execution?: ToolExecution;
+  _meta?: Record<string, unknown>;
 }
 
 export interface ToolCallResult {

--- a/packages/common/src/utils/build-client-context.spec.ts
+++ b/packages/common/src/utils/build-client-context.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { McpTransportType } from '../interfaces/mcp-transport.interface';
+import { buildClientContext, parseBetaHeaders } from './build-client-context';
+
+describe('parseBetaHeaders', () => {
+  it('returns undefined when header is absent', () => {
+    expect(parseBetaHeaders(undefined)).toBeUndefined();
+  });
+
+  it('splits a comma-separated string value', () => {
+    expect(parseBetaHeaders('a, b, c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('trims whitespace around tokens', () => {
+    expect(parseBetaHeaders('  x  ,  y  ')).toEqual(['x', 'y']);
+  });
+
+  it('flattens a string array input', () => {
+    expect(parseBetaHeaders(['a', 'b,c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns undefined when only empty tokens', () => {
+    expect(parseBetaHeaders('  ,  ')).toBeUndefined();
+  });
+});
+
+describe('buildClientContext', () => {
+  it('returns only transport when no request supplied (STDIO case)', () => {
+    const ctx = buildClientContext({ transport: McpTransportType.STDIO });
+    expect(ctx).toEqual({ transport: McpTransportType.STDIO });
+  });
+
+  it('extracts anthropic-beta header from Node-style lowercase headers', () => {
+    const ctx = buildClientContext({
+      transport: McpTransportType.STREAMABLE_HTTP,
+      request: { headers: { 'anthropic-beta': 'advanced-tool-use-2025-11-20' } },
+    });
+    expect(ctx.betaHeaders).toEqual(['advanced-tool-use-2025-11-20']);
+  });
+
+  it('falls back to the title-cased header name if lowercase is missing', () => {
+    const ctx = buildClientContext({
+      transport: McpTransportType.STREAMABLE_HTTP,
+      request: { headers: { 'Anthropic-Beta': 'feature-a' } },
+    });
+    expect(ctx.betaHeaders).toEqual(['feature-a']);
+  });
+
+  it('parses multiple comma-separated beta tokens', () => {
+    const ctx = buildClientContext({
+      transport: McpTransportType.STREAMABLE_HTTP,
+      request: { headers: { 'anthropic-beta': 'a, b, c' } },
+    });
+    expect(ctx.betaHeaders).toEqual(['a', 'b', 'c']);
+  });
+
+  it('passes clientInfo and model through when provided', () => {
+    const ctx = buildClientContext({
+      transport: McpTransportType.SSE,
+      clientInfo: { name: 'client', version: '1.0.0' },
+      model: 'claude-opus-4-7',
+    });
+    expect(ctx.clientInfo).toEqual({ name: 'client', version: '1.0.0' });
+    expect(ctx.model).toBe('claude-opus-4-7');
+  });
+
+  it('omits betaHeaders key when no header is present', () => {
+    const ctx = buildClientContext({
+      transport: McpTransportType.SSE,
+      request: { headers: {} },
+    });
+    expect('betaHeaders' in ctx).toBe(false);
+  });
+});

--- a/packages/common/src/utils/build-client-context.ts
+++ b/packages/common/src/utils/build-client-context.ts
@@ -1,0 +1,54 @@
+import type { ClientContext } from '../interfaces/mcp-exposure.interface';
+import type { McpTransportType } from '../interfaces/mcp-transport.interface';
+
+/**
+ * Narrow shape of the raw transport request object used for header extraction.
+ * Matches Node's IncomingMessage / Fastify / Express without importing them.
+ */
+interface RequestWithHeaders {
+  headers?: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Parses a comma-separated header value (`"a, b, c"`) into trimmed tokens.
+ * Handles both `string` and `string[]` because Node surfaces repeated headers
+ * as arrays.
+ */
+export function parseBetaHeaders(value: string | string[] | undefined): string[] | undefined {
+  if (value == null) return undefined;
+  const raw = Array.isArray(value) ? value.join(',') : value;
+  const parts = raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts : undefined;
+}
+
+export interface BuildClientContextInput {
+  transport: McpTransportType;
+  /** Raw transport request — typed loosely because STDIO has none. */
+  request?: unknown;
+  clientInfo?: { name: string; version: string };
+  model?: string;
+}
+
+/**
+ * Constructs a `ClientContext` from loose transport inputs. Safe to call on
+ * STDIO (no headers) — `betaHeaders` will simply be undefined.
+ *
+ * Header lookup is case-insensitive; Node lowercases incoming header names
+ * for Express/Fastify, so we check the lowercase form first and fall through
+ * to exact-case only as a fallback.
+ */
+export function buildClientContext(input: BuildClientContextInput): ClientContext {
+  const headers = (input.request as RequestWithHeaders | undefined)?.headers;
+  const rawBeta = headers?.['anthropic-beta'] ?? headers?.['Anthropic-Beta'];
+  const betaHeaders = parseBetaHeaders(rawBeta);
+
+  return {
+    transport: input.transport,
+    ...(input.clientInfo ? { clientInfo: input.clientInfo } : {}),
+    ...(input.model ? { model: input.model } : {}),
+    ...(betaHeaders ? { betaHeaders } : {}),
+  };
+}

--- a/packages/common/src/utils/exposure-capabilities.spec.ts
+++ b/packages/common/src/utils/exposure-capabilities.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { McpTransportType } from '../interfaces/mcp-transport.interface';
+import { ANTHROPIC_ADVANCED_TOOL_USE_BETA, clientSupports } from './exposure-capabilities';
+
+describe('clientSupports.search', () => {
+  it('is false when no beta headers are present', () => {
+    expect(clientSupports.search({ transport: McpTransportType.STDIO })).toBe(false);
+  });
+
+  it('is false when beta headers are present but missing the advanced-tool-use token', () => {
+    expect(
+      clientSupports.search({
+        transport: McpTransportType.STREAMABLE_HTTP,
+        betaHeaders: ['prompt-caching-2024-07-31'],
+      }),
+    ).toBe(false);
+  });
+
+  it('is true when the beta header list includes the advanced-tool-use token', () => {
+    expect(
+      clientSupports.search({
+        transport: McpTransportType.STREAMABLE_HTTP,
+        betaHeaders: [ANTHROPIC_ADVANCED_TOOL_USE_BETA],
+      }),
+    ).toBe(true);
+  });
+
+  it('is true when advanced-tool-use appears alongside other beta tokens', () => {
+    expect(
+      clientSupports.search({
+        transport: McpTransportType.STREAMABLE_HTTP,
+        betaHeaders: ['unrelated', ANTHROPIC_ADVANCED_TOOL_USE_BETA, 'another'],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('clientSupports.codeMode', () => {
+  it('is always false in this release', () => {
+    expect(clientSupports.codeMode({ transport: McpTransportType.STDIO })).toBe(false);
+    expect(
+      clientSupports.codeMode({
+        transport: McpTransportType.STREAMABLE_HTTP,
+        betaHeaders: [ANTHROPIC_ADVANCED_TOOL_USE_BETA],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/common/src/utils/exposure-capabilities.ts
+++ b/packages/common/src/utils/exposure-capabilities.ts
@@ -1,0 +1,33 @@
+import type { ClientContext } from '../interfaces/mcp-exposure.interface';
+
+/**
+ * Anthropic beta header identifier that gates the Tool Search Tool feature.
+ * Lives as a constant in the library so consumers don't embed the string —
+ * when Anthropic rotates the identifier or GAs the feature, we ship a patch.
+ */
+export const ANTHROPIC_ADVANCED_TOOL_USE_BETA = 'advanced-tool-use-2025-11-20';
+
+/**
+ * Capability detection for exposure strategies. Uses explicit client signals
+ * (beta headers, capability declarations) rather than model-name regex — the
+ * header is what the Anthropic API itself checks, and it carries forward
+ * across model generations automatically.
+ */
+export const clientSupports = {
+  /**
+   * Returns true if the client has declared support for Anthropic's Tool
+   * Search Tool beta by sending the `anthropic-beta: advanced-tool-use-2025-11-20`
+   * header.
+   */
+  search(ctx: ClientContext): boolean {
+    return ctx.betaHeaders?.includes(ANTHROPIC_ADVANCED_TOOL_USE_BETA) ?? false;
+  },
+
+  /**
+   * Reserved for Code Mode clients (Cloudflare Agents etc). Returns false
+   * until a stable capability signal is specified.
+   */
+  codeMode(_ctx: ClientContext): boolean {
+    return false;
+  },
+};

--- a/packages/common/src/utils/exposure-presets.spec.ts
+++ b/packages/common/src/utils/exposure-presets.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import type { ClientContext } from '../interfaces/mcp-exposure.interface';
+import { type ClientContext, RESOLVER_KINDS } from '../interfaces/mcp-exposure.interface';
 import { McpTransportType } from '../interfaces/mcp-transport.interface';
 import { ANTHROPIC_ADVANCED_TOOL_USE_BETA } from './exposure-capabilities';
-import { preferSearchElseLazy } from './exposure-presets';
+import { defineResolver, preferSearchElseLazy } from './exposure-presets';
 
 function ctx(partial: Partial<ClientContext> = {}): ClientContext {
   return { transport: McpTransportType.STREAMABLE_HTTP, ...partial };
@@ -60,5 +60,34 @@ describe('preferSearchElseLazy', () => {
       indexToolName: 'my_index',
       schemaToolName: 'my_schema',
     });
+  });
+
+  it('declares ["search", "lazy"] via RESOLVER_KINDS so ExposureService can skip conservative meta-tool registration', () => {
+    const resolver = preferSearchElseLazy();
+    expect(resolver[RESOLVER_KINDS]).toEqual(['search', 'lazy']);
+  });
+});
+
+describe('defineResolver', () => {
+  it('attaches the declared kinds to the returned function via RESOLVER_KINDS', () => {
+    const resolver = defineResolver(['search'], () => ({ kind: 'search', variant: 'bm25' }));
+    expect(resolver[RESOLVER_KINDS]).toEqual(['search']);
+  });
+
+  it('still calls through to the underlying resolver function', () => {
+    const resolver = defineResolver(['eager'], () => ({ kind: 'eager' }));
+    expect(resolver(ctx())).toEqual({ kind: 'eager' });
+  });
+
+  it('freezes the kinds array so callers cannot mutate the declaration', () => {
+    const resolver = defineResolver(['search', 'lazy'], () => ({ kind: 'lazy' }));
+    const kinds = resolver[RESOLVER_KINDS];
+    expect(Object.isFrozen(kinds)).toBe(true);
+  });
+
+  it('makes RESOLVER_KINDS non-enumerable so it does not pollute Object.keys', () => {
+    const resolver = defineResolver(['eager'], () => ({ kind: 'eager' }));
+    const keys = Object.getOwnPropertyNames(resolver);
+    expect(keys).not.toContain(String(RESOLVER_KINDS));
   });
 });

--- a/packages/common/src/utils/exposure-presets.spec.ts
+++ b/packages/common/src/utils/exposure-presets.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { ClientContext } from '../interfaces/mcp-exposure.interface';
+import { McpTransportType } from '../interfaces/mcp-transport.interface';
+import { ANTHROPIC_ADVANCED_TOOL_USE_BETA } from './exposure-capabilities';
+import { preferSearchElseLazy } from './exposure-presets';
+
+function ctx(partial: Partial<ClientContext> = {}): ClientContext {
+  return { transport: McpTransportType.STREAMABLE_HTTP, ...partial };
+}
+
+describe('preferSearchElseLazy', () => {
+  it('returns search strategy when the client sent the advanced-tool-use beta header', () => {
+    const resolver = preferSearchElseLazy({ eager: { tags: ['core'] } });
+    const strategy = resolver(ctx({ betaHeaders: [ANTHROPIC_ADVANCED_TOOL_USE_BETA] }));
+    expect(strategy).toEqual({
+      kind: 'search',
+      variant: 'bm25',
+      eager: { tags: ['core'] },
+    });
+  });
+
+  it('returns lazy strategy when the client did not send the beta header', () => {
+    const resolver = preferSearchElseLazy({ eager: { tags: ['core'] } });
+    const strategy = resolver(ctx({ betaHeaders: ['unrelated'] }));
+    expect(strategy).toEqual({
+      kind: 'lazy',
+      eager: { tags: ['core'] },
+    });
+  });
+
+  it('falls back to lazy on STDIO transports (no headers possible)', () => {
+    const resolver = preferSearchElseLazy();
+    const strategy = resolver(ctx({ transport: McpTransportType.STDIO }));
+    expect(strategy.kind).toBe('lazy');
+  });
+
+  it('honours the configured variant when returning search', () => {
+    const resolver = preferSearchElseLazy({ variant: 'regex' });
+    const strategy = resolver(ctx({ betaHeaders: [ANTHROPIC_ADVANCED_TOOL_USE_BETA] }));
+    expect(strategy.kind === 'search' && strategy.variant).toBe('regex');
+  });
+
+  it('threads the eager selector through to both branches', () => {
+    const eager = { tags: ['core'] };
+    const resolver = preferSearchElseLazy({ eager });
+    const searchResult = resolver(ctx({ betaHeaders: [ANTHROPIC_ADVANCED_TOOL_USE_BETA] }));
+    const lazyResult = resolver(ctx());
+    expect(searchResult.kind === 'search' && searchResult.eager).toEqual(eager);
+    expect(lazyResult.kind === 'lazy' && lazyResult.eager).toEqual(eager);
+  });
+
+  it('propagates custom meta-tool names when lazy is selected', () => {
+    const resolver = preferSearchElseLazy({
+      indexToolName: 'my_index',
+      schemaToolName: 'my_schema',
+    });
+    const lazyResult = resolver(ctx());
+    expect(lazyResult).toMatchObject({
+      kind: 'lazy',
+      indexToolName: 'my_index',
+      schemaToolName: 'my_schema',
+    });
+  });
+});

--- a/packages/common/src/utils/exposure-presets.ts
+++ b/packages/common/src/utils/exposure-presets.ts
@@ -8,6 +8,23 @@ import {
 import { clientSupports } from './exposure-capabilities';
 
 /**
+ * Return type of {@link defineResolver}. The declared `kinds` are carried on
+ * the branded property as a literal tuple (via the `const` type parameter),
+ * so downstream consumers — including `ExposureService` — see the exact set
+ * of strategy kinds the resolver can produce rather than the widened
+ * `ExposureStrategy['kind'][]`.
+ *
+ * The return type is also narrowed to `Extract<ExposureStrategy, { kind: K }>`
+ * so callers can rely on the kind discriminant if they introspect the
+ * resolver's output statically.
+ */
+export type DeclaredExposureStrategyResolver<K extends ExposureStrategy['kind']> = ((
+  ctx: ClientContext,
+) => Extract<ExposureStrategy, { kind: K }>) & {
+  readonly [RESOLVER_KINDS]: readonly K[];
+};
+
+/**
  * Wrap a resolver function with a declaration of which strategy kinds it can
  * produce. `ExposureService` uses this declaration to decide whether to
  * register `kind: 'lazy'` meta-tools at bootstrap or leave them off entirely.
@@ -26,17 +43,16 @@ import { clientSupports } from './exposure-capabilities';
  * );
  * ```
  */
-export function defineResolver<K extends ExposureStrategy['kind']>(
+export function defineResolver<const K extends ExposureStrategy['kind']>(
   kinds: readonly K[],
   resolve: (ctx: ClientContext) => Extract<ExposureStrategy, { kind: K }>,
-): ExposureStrategyResolver {
-  const widened = resolve as (ctx: ClientContext) => ExposureStrategy;
-  return Object.defineProperty(widened, RESOLVER_KINDS, {
+): DeclaredExposureStrategyResolver<K> {
+  return Object.defineProperty(resolve, RESOLVER_KINDS, {
     value: Object.freeze([...kinds]),
     enumerable: false,
     writable: false,
     configurable: false,
-  }) as ExposureStrategyResolver;
+  }) as DeclaredExposureStrategyResolver<K>;
 }
 
 export interface PreferSearchElseLazyOptions {

--- a/packages/common/src/utils/exposure-presets.ts
+++ b/packages/common/src/utils/exposure-presets.ts
@@ -1,5 +1,43 @@
-import type { ExposureStrategyResolver, ToolSelector } from '../interfaces/mcp-exposure.interface';
+import {
+  type ClientContext,
+  type ExposureStrategy,
+  type ExposureStrategyResolver,
+  RESOLVER_KINDS,
+  type ToolSelector,
+} from '../interfaces/mcp-exposure.interface';
 import { clientSupports } from './exposure-capabilities';
+
+/**
+ * Wrap a resolver function with a declaration of which strategy kinds it can
+ * produce. `ExposureService` uses this declaration to decide whether to
+ * register `kind: 'lazy'` meta-tools at bootstrap or leave them off entirely.
+ *
+ * Without this wrapper, the service must assume a plain resolver *could*
+ * return `lazy` and registers meta-tools defensively — a safe default, but
+ * one that pollutes the registry when the resolver never actually returns
+ * `lazy`. Declaring kinds up front eliminates that drift.
+ *
+ * @example
+ * ```ts
+ * const exposure = defineResolver(['search', 'lazy'], (ctx) =>
+ *   clientSupports.search(ctx)
+ *     ? { kind: 'search', variant: 'bm25', eager: { tags: ['core'] } }
+ *     : { kind: 'lazy', eager: { tags: ['core'] } },
+ * );
+ * ```
+ */
+export function defineResolver<K extends ExposureStrategy['kind']>(
+  kinds: readonly K[],
+  resolve: (ctx: ClientContext) => Extract<ExposureStrategy, { kind: K }>,
+): ExposureStrategyResolver {
+  const widened = resolve as (ctx: ClientContext) => ExposureStrategy;
+  return Object.defineProperty(widened, RESOLVER_KINDS, {
+    value: Object.freeze([...kinds]),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  }) as ExposureStrategyResolver;
+}
 
 export interface PreferSearchElseLazyOptions {
   /** Tool selector shared across both strategies. */
@@ -29,7 +67,7 @@ export function preferSearchElseLazy(
   options: PreferSearchElseLazyOptions = {},
 ): ExposureStrategyResolver {
   const { eager, variant = 'bm25', indexToolName, schemaToolName } = options;
-  return (ctx) =>
+  return defineResolver(['search', 'lazy'], (ctx) =>
     clientSupports.search(ctx)
       ? { kind: 'search', variant, eager }
       : {
@@ -37,5 +75,6 @@ export function preferSearchElseLazy(
           eager,
           ...(indexToolName ? { indexToolName } : {}),
           ...(schemaToolName ? { schemaToolName } : {}),
-        };
+        },
+  );
 }

--- a/packages/common/src/utils/exposure-presets.ts
+++ b/packages/common/src/utils/exposure-presets.ts
@@ -1,0 +1,41 @@
+import type { ExposureStrategyResolver, ToolSelector } from '../interfaces/mcp-exposure.interface';
+import { clientSupports } from './exposure-capabilities';
+
+export interface PreferSearchElseLazyOptions {
+  /** Tool selector shared across both strategies. */
+  eager?: ToolSelector;
+  /** Search variant when `search` is selected. Default: `bm25`. */
+  variant?: 'regex' | 'bm25';
+  /** Index meta-tool name when `lazy` is selected. */
+  indexToolName?: string;
+  /** Schema-fetch meta-tool name when `lazy` is selected. */
+  schemaToolName?: string;
+}
+
+/**
+ * Preset resolver: emits `kind: 'search'` for clients that declared the
+ * advanced-tool-use beta header, otherwise falls back to `kind: 'lazy'`.
+ * Never returns `eager` — this preset is meant for catalogs that would
+ * bloat context if surfaced up front.
+ *
+ * @example
+ * ```ts
+ * McpModule.forRoot({
+ *   exposure: preferSearchElseLazy({ eager: { tags: ['core'] } }),
+ * });
+ * ```
+ */
+export function preferSearchElseLazy(
+  options: PreferSearchElseLazyOptions = {},
+): ExposureStrategyResolver {
+  const { eager, variant = 'bm25', indexToolName, schemaToolName } = options;
+  return (ctx) =>
+    clientSupports.search(ctx)
+      ? { kind: 'search', variant, eager }
+      : {
+          kind: 'lazy',
+          eager,
+          ...(indexToolName ? { indexToolName } : {}),
+          ...(schemaToolName ? { schemaToolName } : {}),
+        };
+}

--- a/packages/server/src/decorators/tool.decorator.ts
+++ b/packages/server/src/decorators/tool.decorator.ts
@@ -13,6 +13,8 @@ export function Tool(options: ToolOptions): MethodDecorator {
       ...(options.icons != null ? { icons: options.icons } : {}),
       ...(options.execution != null ? { execution: options.execution } : {}),
       ...('_meta' in options && options._meta != null ? { _meta: options._meta } : {}),
+      ...(options.tags != null ? { tags: options.tags } : {}),
+      ...(options.exposure != null ? { exposure: options.exposure } : {}),
       methodName: String(propertyKey),
       target: target.constructor as abstract new (...args: unknown[]) => unknown,
     };

--- a/packages/server/src/execution/executor.service.ts
+++ b/packages/server/src/execution/executor.service.ts
@@ -9,6 +9,7 @@ import {
   type ResourceReadResult,
   type ToolCallResult,
   ToolExecutionError,
+  type ToolListEntry,
   ValidationError,
   extractZodDescriptions,
   matchUriTemplate,
@@ -41,27 +42,29 @@ export class McpExecutorService {
    * pagination — filtering or annotating entries post-pagination would
    * produce uneven page sizes.
    */
-  buildToolEntries(): Array<Record<string, unknown>> {
-    return this.registry.getAllTools().map((tool) => ({
-      name: tool.name,
-      ...(tool.title != null ? { title: tool.title } : {}),
-      description: tool.description,
-      inputSchema: tool.parameters
-        ? zodToJsonSchema(tool.parameters)
-        : (tool.inputSchema ?? { type: 'object' }),
-      ...(tool.outputSchema
-        ? { outputSchema: zodToJsonSchema(tool.outputSchema) }
-        : tool.rawOutputSchema
-          ? { outputSchema: tool.rawOutputSchema }
-          : {}),
-      ...(tool.annotations ? { annotations: tool.annotations } : {}),
-      ...(tool.icons ? { icons: tool.icons } : {}),
-      ...(tool.execution ? { execution: tool.execution } : {}),
-      ...(tool._meta ? { _meta: tool._meta } : {}),
-    }));
+  buildToolEntries(): ToolListEntry[] {
+    return this.registry.getAllTools().map((tool): ToolListEntry => {
+      const inputSchema = tool.parameters
+        ? (zodToJsonSchema(tool.parameters) as Record<string, unknown>)
+        : (tool.inputSchema ?? { type: 'object' });
+      const outputSchema = tool.outputSchema
+        ? (zodToJsonSchema(tool.outputSchema) as Record<string, unknown>)
+        : tool.rawOutputSchema;
+      return {
+        name: tool.name,
+        ...(tool.title != null ? { title: tool.title } : {}),
+        description: tool.description,
+        inputSchema,
+        ...(outputSchema ? { outputSchema } : {}),
+        ...(tool.annotations ? { annotations: tool.annotations } : {}),
+        ...(tool.icons ? { icons: tool.icons } : {}),
+        ...(tool.execution ? { execution: tool.execution } : {}),
+        ...(tool._meta ? { _meta: tool._meta } : {}),
+      };
+    });
   }
 
-  async listTools(cursor?: string): Promise<PaginatedResult<Record<string, unknown>>> {
+  async listTools(cursor?: string): Promise<PaginatedResult<ToolListEntry>> {
     return paginate(this.buildToolEntries(), cursor, this.pageSize);
   }
 

--- a/packages/server/src/execution/executor.service.ts
+++ b/packages/server/src/execution/executor.service.ts
@@ -34,8 +34,15 @@ export class McpExecutorService {
 
   // ---- Tools ----
 
-  async listTools(cursor?: string): Promise<PaginatedResult<Record<string, unknown>>> {
-    const all = this.registry.getAllTools().map((tool) => ({
+  /**
+   * Build the full list of tool entries (unpaginated) in the same shape
+   * surfaced by `tools/list`. Exposed so that the pipeline can insert a
+   * catalog-presentation transform (see {@link ExposureService}) before
+   * pagination — filtering or annotating entries post-pagination would
+   * produce uneven page sizes.
+   */
+  buildToolEntries(): Array<Record<string, unknown>> {
+    return this.registry.getAllTools().map((tool) => ({
       name: tool.name,
       ...(tool.title != null ? { title: tool.title } : {}),
       description: tool.description,
@@ -52,7 +59,10 @@ export class McpExecutorService {
       ...(tool.execution ? { execution: tool.execution } : {}),
       ...(tool._meta ? { _meta: tool._meta } : {}),
     }));
-    return paginate(all, cursor, this.pageSize);
+  }
+
+  async listTools(cursor?: string): Promise<PaginatedResult<Record<string, unknown>>> {
+    return paginate(this.buildToolEntries(), cursor, this.pageSize);
   }
 
   async callTool(

--- a/packages/server/src/execution/pipeline.service.ts
+++ b/packages/server/src/execution/pipeline.service.ts
@@ -1,5 +1,6 @@
 import type {
   CircuitBreakerConfig,
+  ClientContext,
   CompletionRequest,
   CompletionResult,
   McpExecutionContext,
@@ -10,6 +11,7 @@ import type {
   ResourceReadResult,
   RetryConfig,
   ToolCallResult,
+  ToolMetadata,
 } from '@nest-mcp/common';
 import type { McpGuard, McpGuardClass } from '@nest-mcp/common';
 import {
@@ -18,11 +20,13 @@ import {
   McpError,
   McpTimeoutError,
   ToolExecutionError,
+  paginate,
 } from '@nest-mcp/common';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { ToolAuthGuardService } from '../auth/guards/tool-auth.guard';
 import { McpRegistryService } from '../discovery/registry.service';
+import { ExposureService } from '../exposure/exposure.service';
 import { MiddlewareService } from '../middleware/middleware.service';
 import { MetricsService } from '../observability/metrics.service';
 import { CircuitBreakerService } from '../resilience/circuit-breaker.service';
@@ -47,6 +51,7 @@ export class ExecutionPipelineService {
     @Inject(MCP_OPTIONS) private readonly options: McpModuleOptions,
     private readonly moduleRef: ModuleRef,
     private readonly requestContext: McpRequestContextService,
+    private readonly exposure: ExposureService,
   ) {}
 
   // ---- Tools ----
@@ -185,8 +190,18 @@ export class ExecutionPipelineService {
 
   // ---- List methods (delegate directly) ----
 
-  async listTools(cursor?: string) {
-    return this.executor.listTools(cursor);
+  async listTools(cursor?: string, ctx?: ClientContext) {
+    // When a client context is supplied, apply the exposure strategy before
+    // paginating so filtered strategies (e.g. `lazy`) produce even page sizes.
+    if (!ctx) {
+      return this.executor.listTools(cursor);
+    }
+    const entries = this.executor.buildToolEntries();
+    const metaMap = new Map<string, ToolMetadata>(
+      this.registry.getAllTools().map((t) => [t.name, t]),
+    );
+    const shaped = this.exposure.applyStrategy(entries, metaMap, ctx);
+    return paginate(shaped, cursor, this.options.pagination?.defaultPageSize);
   }
 
   async listResources(cursor?: string) {

--- a/packages/server/src/exposure/exposure.service.spec.ts
+++ b/packages/server/src/exposure/exposure.service.spec.ts
@@ -7,6 +7,7 @@ import {
   type McpModuleOptions,
   McpTransportType,
   type ToolMetadata,
+  defineResolver,
 } from '@nest-mcp/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { McpRegistryService, RegisteredTool } from '../discovery/registry.service';
@@ -202,9 +203,32 @@ describe('ExposureService — meta-tool registration (onApplicationBootstrap)', 
     ]);
   });
 
-  it('conservatively registers meta-tools when a resolver is configured', () => {
+  it('conservatively registers meta-tools when an undeclared resolver is configured', () => {
     const registry = makeRegistry();
     const resolver: ExposureStrategyResolver = () => ({ kind: 'search', variant: 'bm25' });
+    const svc = new ExposureService({ ...baseOptions, exposure: resolver }, registry);
+    svc.onApplicationBootstrap();
+    expect(registry.__added.map((t) => t.name).sort()).toEqual([
+      'get_tool_schema',
+      'list_available_tools',
+    ]);
+  });
+
+  it('skips meta-tool registration when defineResolver declares only non-lazy kinds', () => {
+    const registry = makeRegistry();
+    const resolver = defineResolver(['search'], () => ({ kind: 'search', variant: 'bm25' }));
+    const svc = new ExposureService({ ...baseOptions, exposure: resolver }, registry);
+    svc.onApplicationBootstrap();
+    expect(registry.__added).toHaveLength(0);
+  });
+
+  it('registers meta-tools when defineResolver declares lazy among its kinds', () => {
+    const registry = makeRegistry();
+    const resolver = defineResolver(['search', 'lazy'], (ctx) =>
+      ctx.betaHeaders?.includes(ANTHROPIC_ADVANCED_TOOL_USE_BETA)
+        ? { kind: 'search', variant: 'bm25' }
+        : { kind: 'lazy' },
+    );
     const svc = new ExposureService({ ...baseOptions, exposure: resolver }, registry);
     svc.onApplicationBootstrap();
     expect(registry.__added.map((t) => t.name).sort()).toEqual([

--- a/packages/server/src/exposure/exposure.service.spec.ts
+++ b/packages/server/src/exposure/exposure.service.spec.ts
@@ -18,7 +18,7 @@ function makeTool(overrides: Partial<RegisteredTool>): RegisteredTool {
     name: 'tool',
     description: 'desc',
     methodName: 'fn',
-    target: class {} as unknown as abstract new (...args: unknown[]) => unknown,
+    target: class {},
     instance: {},
     ...overrides,
   };

--- a/packages/server/src/exposure/exposure.service.spec.ts
+++ b/packages/server/src/exposure/exposure.service.spec.ts
@@ -1,0 +1,368 @@
+import { EventEmitter } from 'node:events';
+import {
+  ANTHROPIC_ADVANCED_TOOL_USE_BETA,
+  type ClientContext,
+  type ExposureStrategyResolver,
+  META_DEFER_LOADING,
+  type McpModuleOptions,
+  McpTransportType,
+  type ToolMetadata,
+} from '@nest-mcp/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpRegistryService, RegisteredTool } from '../discovery/registry.service';
+import { ExposureService } from './exposure.service';
+
+function makeTool(overrides: Partial<RegisteredTool>): RegisteredTool {
+  return {
+    name: 'tool',
+    description: 'desc',
+    methodName: 'fn',
+    target: class {} as unknown as abstract new (...args: unknown[]) => unknown,
+    instance: {},
+    ...overrides,
+  };
+}
+
+function makeEntry(name: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return { name, description: `${name} description`, inputSchema: { type: 'object' }, ...extra };
+}
+
+function makeRegistry(
+  tools: RegisteredTool[] = [],
+): McpRegistryService & { __added: RegisteredTool[] } {
+  const byName = new Map<string, RegisteredTool>(tools.map((t) => [t.name, t]));
+  const added: RegisteredTool[] = [];
+  const mock = {
+    events: new EventEmitter(),
+    getAllTools: vi.fn(() => Array.from(byName.values())),
+    getTool: vi.fn((name: string) => byName.get(name)),
+    registerTool: vi.fn((tool: RegisteredTool) => {
+      byName.set(tool.name, tool);
+      added.push(tool);
+    }),
+    unregisterTool: vi.fn(),
+    __added: added,
+  };
+  return mock as unknown as McpRegistryService & { __added: RegisteredTool[] };
+}
+
+function ctx(partial: Partial<ClientContext> = {}): ClientContext {
+  return { transport: McpTransportType.STREAMABLE_HTTP, ...partial };
+}
+
+const baseOptions: McpModuleOptions = {
+  name: 'test',
+  version: '0.0.0',
+  transport: McpTransportType.STREAMABLE_HTTP,
+};
+
+describe('ExposureService — resolveForClient', () => {
+  it('returns the static strategy verbatim', () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'eager' } },
+      makeRegistry(),
+    );
+    expect(svc.resolveForClient(ctx())).toEqual({ kind: 'eager' });
+  });
+
+  it('invokes the resolver function with the provided client context', () => {
+    const spy: ExposureStrategyResolver = vi.fn(() => ({ kind: 'eager' }));
+    const svc = new ExposureService({ ...baseOptions, exposure: spy }, makeRegistry());
+    const c = ctx({ model: 'claude-opus-4-7' });
+    svc.resolveForClient(c);
+    expect(spy).toHaveBeenCalledWith(c);
+  });
+
+  it('defaults to eager when no exposure is configured', () => {
+    const svc = new ExposureService(baseOptions, makeRegistry());
+    expect(svc.resolveForClient(ctx())).toEqual({ kind: 'eager' });
+  });
+});
+
+describe('ExposureService — applyStrategy: eager', () => {
+  it('returns entries unchanged under eager', () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'eager' } },
+      makeRegistry(),
+    );
+    const entries = [makeEntry('a'), makeEntry('b')];
+    const metas = new Map<string, ToolMetadata>([
+      ['a', makeTool({ name: 'a' })],
+      ['b', makeTool({ name: 'b' })],
+    ]);
+    expect(svc.applyStrategy(entries, metas, ctx())).toEqual(entries);
+  });
+});
+
+describe('ExposureService — applyStrategy: search', () => {
+  it('annotates deferred entries with _meta.defer_loading = true', () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'search', variant: 'bm25', eager: { tags: ['core'] } } },
+      makeRegistry(),
+    );
+    const entries = [makeEntry('a'), makeEntry('b')];
+    const metas = new Map<string, ToolMetadata>([
+      ['a', makeTool({ name: 'a', tags: ['core'] })],
+      ['b', makeTool({ name: 'b', tags: ['rare'] })],
+    ]);
+    const result = svc.applyStrategy(entries, metas, ctx());
+    expect(result[0]._meta).toBeUndefined();
+    expect(result[1]._meta).toEqual({ [META_DEFER_LOADING]: true });
+  });
+
+  it('preserves existing _meta entries when annotating', () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'search', variant: 'bm25', eager: ['a'] } },
+      makeRegistry(),
+    );
+    const entries = [makeEntry('b', { _meta: { vendor: 'x' } })];
+    const metas = new Map<string, ToolMetadata>([['b', makeTool({ name: 'b' })]]);
+    const result = svc.applyStrategy(entries, metas, ctx());
+    expect(result[0]._meta).toEqual({ vendor: 'x', [META_DEFER_LOADING]: true });
+  });
+
+  it('respects per-tool exposure: "eager" even when selector does not include the tool', () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'search', variant: 'bm25', eager: ['nothing'] } },
+      makeRegistry(),
+    );
+    const entries = [makeEntry('a')];
+    const metas = new Map<string, ToolMetadata>([
+      ['a', makeTool({ name: 'a', exposure: 'eager' })],
+    ]);
+    const result = svc.applyStrategy(entries, metas, ctx());
+    expect(result[0]._meta).toBeUndefined();
+  });
+});
+
+describe('ExposureService — applyStrategy: lazy', () => {
+  it('filters out tools that do not match the eager selector', () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'lazy', eager: { tags: ['core'] } } },
+      makeRegistry(),
+    );
+    const entries = [makeEntry('a'), makeEntry('b'), makeEntry('c')];
+    const metas = new Map<string, ToolMetadata>([
+      ['a', makeTool({ name: 'a', tags: ['core'] })],
+      ['b', makeTool({ name: 'b', tags: ['rare'] })],
+      ['c', makeTool({ name: 'c', tags: ['core', 'rare'] })],
+    ]);
+    const result = svc.applyStrategy(entries, metas, ctx());
+    const names = result.map((e) => e.name);
+    expect(names).toContain('a');
+    expect(names).toContain('c');
+    expect(names).not.toContain('b');
+  });
+
+  it('keeps the meta-tools in the response when kind is lazy', () => {
+    const registry = makeRegistry();
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'lazy', eager: [] } },
+      registry,
+    );
+    svc.onApplicationBootstrap();
+    expect(registry.__added.map((t) => t.name).sort()).toEqual([
+      'get_tool_schema',
+      'list_available_tools',
+    ]);
+
+    const entries = [
+      makeEntry('a'),
+      makeEntry('list_available_tools'),
+      makeEntry('get_tool_schema'),
+    ];
+    const metas = new Map<string, ToolMetadata>([
+      ['a', makeTool({ name: 'a', tags: [] })],
+      ['list_available_tools', makeTool({ name: 'list_available_tools', exposure: 'eager' })],
+      ['get_tool_schema', makeTool({ name: 'get_tool_schema', exposure: 'eager' })],
+    ]);
+    const result = svc.applyStrategy(entries, metas, ctx());
+    const names = result.map((e) => e.name);
+    expect(names).toContain('list_available_tools');
+    expect(names).toContain('get_tool_schema');
+    expect(names).not.toContain('a'); // 'a' is not eager
+  });
+});
+
+describe('ExposureService — meta-tool registration (onApplicationBootstrap)', () => {
+  it('does not register meta-tools for eager-only configurations', () => {
+    const registry = makeRegistry();
+    const svc = new ExposureService({ ...baseOptions, exposure: { kind: 'eager' } }, registry);
+    svc.onApplicationBootstrap();
+    expect(registry.__added).toHaveLength(0);
+  });
+
+  it('registers lazy meta-tools on bootstrap when lazy is reachable', () => {
+    const registry = makeRegistry();
+    const svc = new ExposureService({ ...baseOptions, exposure: { kind: 'lazy' } }, registry);
+    svc.onApplicationBootstrap();
+    expect(registry.__added.map((t) => t.name).sort()).toEqual([
+      'get_tool_schema',
+      'list_available_tools',
+    ]);
+  });
+
+  it('conservatively registers meta-tools when a resolver is configured', () => {
+    const registry = makeRegistry();
+    const resolver: ExposureStrategyResolver = () => ({ kind: 'search', variant: 'bm25' });
+    const svc = new ExposureService({ ...baseOptions, exposure: resolver }, registry);
+    svc.onApplicationBootstrap();
+    expect(registry.__added.map((t) => t.name).sort()).toEqual([
+      'get_tool_schema',
+      'list_available_tools',
+    ]);
+  });
+
+  it('honours custom indexToolName / schemaToolName', () => {
+    const registry = makeRegistry();
+    const svc = new ExposureService(
+      {
+        ...baseOptions,
+        exposure: { kind: 'lazy', indexToolName: 'my_index', schemaToolName: 'my_schema' },
+      },
+      registry,
+    );
+    svc.onApplicationBootstrap();
+    expect(registry.__added.map((t) => t.name).sort()).toEqual(['my_index', 'my_schema']);
+  });
+});
+
+describe('ExposureService — validation (onApplicationBootstrap)', () => {
+  it('throws when a meta-tool name collides with an existing tool', () => {
+    const existing = makeTool({ name: 'list_available_tools' });
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'lazy' } },
+      makeRegistry([existing]),
+    );
+    expect(() => svc.onApplicationBootstrap()).toThrow(/collides with an existing tool/);
+  });
+
+  it('throws when kind: search has zero eager tools (default behavior)', () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'search', variant: 'bm25', eager: ['nonexistent'] } },
+      makeRegistry([makeTool({ name: 'a' }), makeTool({ name: 'b' })]),
+    );
+    expect(() => svc.onApplicationBootstrap()).toThrow(/zero eager tools/);
+  });
+
+  it('does not throw when onAllDeferred is "warn"', () => {
+    const svc = new ExposureService(
+      {
+        ...baseOptions,
+        exposure: {
+          kind: 'search',
+          variant: 'bm25',
+          eager: ['nonexistent'],
+          onAllDeferred: 'warn',
+        },
+      },
+      makeRegistry([makeTool({ name: 'a' })]),
+    );
+    expect(() => svc.onApplicationBootstrap()).not.toThrow();
+  });
+
+  it('skips search validation when the strategy is a resolver (non-static)', () => {
+    const svc = new ExposureService(
+      {
+        ...baseOptions,
+        exposure: () => ({ kind: 'search', variant: 'bm25', eager: ['nonexistent'] }),
+      },
+      makeRegistry([makeTool({ name: 'a' })]),
+    );
+    expect(() => svc.onApplicationBootstrap()).not.toThrow();
+  });
+});
+
+describe('ExposureService — handleListAvailableTools', () => {
+  it('returns tools without schemas, paginated', async () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'lazy' } },
+      makeRegistry([
+        makeTool({ name: 'alpha', description: 'first tool' }),
+        makeTool({ name: 'beta', description: 'second tool' }),
+      ]),
+    );
+    svc.onApplicationBootstrap();
+    const result = await svc.handleListAvailableTools({});
+    // The meta-tools should not appear in the index.
+    expect(result.tools.map((t) => t.name).sort()).toEqual(['alpha', 'beta']);
+    for (const t of result.tools) {
+      expect('inputSchema' in t).toBe(false);
+    }
+  });
+
+  it('filters by query substring on name or description', async () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'lazy' } },
+      makeRegistry([
+        makeTool({ name: 'search_issues', description: 'find issues' }),
+        makeTool({ name: 'list_repos', description: 'enumerate repositories' }),
+      ]),
+    );
+    svc.onApplicationBootstrap();
+    const result = await svc.handleListAvailableTools({ query: 'issue' });
+    expect(result.tools.map((t) => t.name)).toEqual(['search_issues']);
+  });
+
+  it('filters by AND of tags', async () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'lazy' } },
+      makeRegistry([
+        makeTool({ name: 'a', tags: ['core', 'fast'] }),
+        makeTool({ name: 'b', tags: ['core'] }),
+        makeTool({ name: 'c', tags: ['rare', 'fast'] }),
+      ]),
+    );
+    svc.onApplicationBootstrap();
+    const result = await svc.handleListAvailableTools({ tags: ['core', 'fast'] });
+    expect(result.tools.map((t) => t.name)).toEqual(['a']);
+  });
+});
+
+describe('ExposureService — handleGetToolSchema', () => {
+  it('returns full schemas for known names and records unknowns in notFound', async () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'lazy' } },
+      makeRegistry([
+        makeTool({
+          name: 'alpha',
+          description: 'first',
+          inputSchema: { type: 'object', properties: { x: { type: 'string' } } },
+        }),
+      ]),
+    );
+    svc.onApplicationBootstrap();
+    const result = await svc.handleGetToolSchema({ names: ['alpha', 'ghost'] });
+    expect(result.notFound).toEqual(['ghost']);
+    expect(result.schemas).toHaveLength(1);
+    expect(result.schemas[0]?.name).toBe('alpha');
+    expect(result.schemas[0]?.inputSchema).toEqual({
+      type: 'object',
+      properties: { x: { type: 'string' } },
+    });
+  });
+
+  it('caps batch size to maxBatchSize', async () => {
+    const svc = new ExposureService(
+      { ...baseOptions, exposure: { kind: 'lazy', maxBatchSize: 2 } },
+      makeRegistry([makeTool({ name: 'a' }), makeTool({ name: 'b' }), makeTool({ name: 'c' })]),
+    );
+    svc.onApplicationBootstrap();
+    const result = await svc.handleGetToolSchema({ names: ['a', 'b', 'c'] });
+    expect(result.schemas.map((s) => s.name)).toEqual(['a', 'b']);
+  });
+});
+
+describe('ExposureService — integration with capability helpers', () => {
+  it('a resolver using clientSupports.search picks search when the beta header is present', () => {
+    const resolver: ExposureStrategyResolver = (c) =>
+      c.betaHeaders?.includes(ANTHROPIC_ADVANCED_TOOL_USE_BETA)
+        ? { kind: 'search', variant: 'bm25' }
+        : { kind: 'lazy' };
+    const svc = new ExposureService({ ...baseOptions, exposure: resolver }, makeRegistry());
+    const withBeta = svc.resolveForClient(ctx({ betaHeaders: [ANTHROPIC_ADVANCED_TOOL_USE_BETA] }));
+    const withoutBeta = svc.resolveForClient(ctx());
+    expect(withBeta.kind).toBe('search');
+    expect(withoutBeta.kind).toBe('lazy');
+  });
+});

--- a/packages/server/src/exposure/exposure.service.ts
+++ b/packages/server/src/exposure/exposure.service.ts
@@ -5,6 +5,7 @@ import {
   MCP_OPTIONS,
   META_DEFER_LOADING,
   type McpModuleOptions,
+  RESOLVER_KINDS,
   type ToolMetadata,
 } from '@nest-mcp/common';
 import { Inject, Injectable, Logger, type OnApplicationBootstrap } from '@nestjs/common';
@@ -197,14 +198,43 @@ export class ExposureService implements OnApplicationBootstrap {
   }
 
   private canResolveToLazy(): boolean {
-    // Resolver form: we can't know statically what it returns. Register to be safe.
-    if (typeof this.configured === 'function') return true;
-    return this.configured.kind === 'lazy';
+    return this.canResolveTo('lazy');
   }
 
   private canResolveToSearch(): boolean {
-    if (typeof this.configured === 'function') return true;
-    return this.configured.kind === 'search';
+    return this.canResolveTo('search');
+  }
+
+  /**
+   * Decide whether the configured strategy could resolve to a given kind.
+   *
+   * - Static strategies: exact answer from the `kind` discriminant.
+   * - Resolver functions with declared kinds (via `defineResolver`): exact
+   *   answer from the declaration.
+   * - Plain resolver functions: conservative `true`, with a one-time warning
+   *   suggesting the user wrap with `defineResolver` to tighten behavior.
+   */
+  private canResolveTo(kind: ExposureStrategy['kind']): boolean {
+    if (typeof this.configured !== 'function') {
+      return this.configured.kind === kind;
+    }
+    const declared = this.configured[RESOLVER_KINDS];
+    if (declared) {
+      return declared.includes(kind);
+    }
+    this.warnUndeclaredResolverOnce();
+    return true; // conservative fallback
+  }
+
+  private warnedUndeclaredResolver = false;
+
+  private warnUndeclaredResolverOnce(): void {
+    if (this.warnedUndeclaredResolver) return;
+    this.warnedUndeclaredResolver = true;
+    this.logger.warn(
+      'ExposureService: the configured resolver does not declare which strategy kinds it can produce. ' +
+        'Wrap with `defineResolver([...kinds], fn)` from @nest-mcp/common to avoid conservative meta-tool registration.',
+    );
   }
 
   // ---- Registration ----

--- a/packages/server/src/exposure/exposure.service.ts
+++ b/packages/server/src/exposure/exposure.service.ts
@@ -1,0 +1,275 @@
+import {
+  type ClientContext,
+  type ExposureStrategy,
+  type ExposureStrategyResolver,
+  MCP_OPTIONS,
+  META_DEFER_LOADING,
+  type McpModuleOptions,
+  type ToolMetadata,
+} from '@nest-mcp/common';
+import { Inject, Injectable, Logger, type OnApplicationBootstrap } from '@nestjs/common';
+import { McpRegistryService } from '../discovery/registry.service';
+import type { RegisteredTool } from '../discovery/registry.service';
+import {
+  DEFAULT_SCHEMA_TOOL_DESCRIPTION,
+  DEFAULT_SCHEMA_TOOL_NAME,
+  type GetToolSchemaArgs,
+  type GetToolSchemaResult,
+  getToolSchema,
+  getToolSchemaSchema,
+} from './meta-tools/get-tool-schema';
+import {
+  DEFAULT_LIST_TOOL_DESCRIPTION,
+  DEFAULT_LIST_TOOL_NAME,
+  type ListAvailableToolsArgs,
+  type ListAvailableToolsResult,
+  listAvailableTools,
+  listAvailableToolsSchema,
+} from './meta-tools/list-available-tools';
+import { isEager } from './selector';
+
+interface ResolvedMetaToolNames {
+  indexToolName: string;
+  schemaToolName: string;
+}
+
+/**
+ * Applies a catalog-presentation strategy to `tools/list` responses.
+ *
+ * Responsibilities:
+ *  - Resolve the concrete strategy for each client (static option or resolver).
+ *  - Transform executor-built tool entries per the resolved strategy:
+ *    `eager` (no-op), `search` (annotate with `_meta.defer_loading`),
+ *    `lazy` (filter to eager + meta-tools), `typed-api` (reserved).
+ *  - Register the `list_available_tools` / `get_tool_schema` meta-tools
+ *    at bootstrap when `lazy` is reachable.
+ *  - Validate config at application bootstrap (name collisions, all-deferred,
+ *    incompatible combinations).
+ *
+ * The service is a singleton and pure-per-request: client state lives in the
+ * {@link ClientContext} parameter, never on the service.
+ */
+@Injectable()
+export class ExposureService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(ExposureService.name);
+  private readonly configured: ExposureStrategy | ExposureStrategyResolver;
+  private readonly metaToolNames = new Set<string>();
+  private readonly metaToolConfig: ResolvedMetaToolNames;
+  private readonly maxBatchSize: number;
+
+  constructor(
+    @Inject(MCP_OPTIONS) private readonly options: McpModuleOptions,
+    private readonly registry: McpRegistryService,
+  ) {
+    this.configured = options.exposure ?? { kind: 'eager' };
+    const lazyHint = this.lazyHint();
+    this.metaToolConfig = {
+      indexToolName: lazyHint?.indexToolName ?? DEFAULT_LIST_TOOL_NAME,
+      schemaToolName: lazyHint?.schemaToolName ?? DEFAULT_SCHEMA_TOOL_NAME,
+    };
+    this.maxBatchSize = lazyHint?.maxBatchSize ?? 20;
+  }
+
+  /**
+   * Runs after all `onModuleInit` hooks (including the scanner) have populated
+   * the registry. We validate collisions against the scanned tools *before*
+   * registering our meta-tools so an existing tool with the same name is a
+   * hard error, not a silent overwrite.
+   */
+  onApplicationBootstrap(): void {
+    if (this.canResolveToLazy()) {
+      this.validateNameCollisions();
+      this.registerMetaTools();
+    }
+    this.validateSearchReachable();
+  }
+
+  // ---- Public API ----
+
+  /**
+   * Resolve the concrete strategy for the given client context. If the
+   * module was configured with a static strategy, returns it unchanged;
+   * if configured with a resolver function, invokes it with `ctx`.
+   */
+  resolveForClient(ctx: ClientContext): ExposureStrategy {
+    return typeof this.configured === 'function' ? this.configured(ctx) : this.configured;
+  }
+
+  /**
+   * Transform a list of tool entries (as produced by the executor) according
+   * to the resolved strategy. Meta-tools are always present in the registry
+   * but only surfaced in the response when `kind: 'lazy'` is active.
+   *
+   * @param entries - Pre-mapped tool entries (one per registered tool).
+   * @param metas   - Parallel map of tool name to metadata, for selector evaluation.
+   * @param ctx     - Client context used to resolve the strategy.
+   */
+  applyStrategy(
+    entries: Array<Record<string, unknown>>,
+    metas: Map<string, ToolMetadata>,
+    ctx: ClientContext,
+  ): Array<Record<string, unknown>> {
+    const strategy = this.resolveForClient(ctx);
+
+    switch (strategy.kind) {
+      case 'eager':
+        return this.withoutMetaTools(entries);
+      case 'search':
+        return this.applySearch(entries, metas, strategy.eager);
+      case 'lazy':
+        return this.applyLazy(entries, metas, strategy.eager);
+      case 'typed-api':
+        throw new Error(
+          "ExposureStrategy kind 'typed-api' is reserved and not implemented in this release",
+        );
+    }
+  }
+
+  // ---- Meta-tool handlers (invoked by the executor via registerTool) ----
+
+  async handleListAvailableTools(args: ListAvailableToolsArgs): Promise<ListAvailableToolsResult> {
+    const all = this.registry.getAllTools();
+    const entries = all
+      .filter((t) => !this.metaToolNames.has(t.name))
+      .map((meta) => ({
+        meta,
+        oneLineDescription: meta.description.split('\n')[0] ?? meta.description,
+      }));
+    return listAvailableTools(entries, args);
+  }
+
+  async handleGetToolSchema(args: GetToolSchemaArgs): Promise<GetToolSchemaResult> {
+    const pool = new Map<string, ToolMetadata>();
+    for (const t of this.registry.getAllTools()) {
+      if (!this.metaToolNames.has(t.name)) pool.set(t.name, t);
+    }
+    return getToolSchema(pool, args, this.maxBatchSize);
+  }
+
+  // ---- Strategy implementations ----
+
+  private applySearch(
+    entries: Array<Record<string, unknown>>,
+    metas: Map<string, ToolMetadata>,
+    eager: Parameters<typeof isEager>[1],
+  ): Array<Record<string, unknown>> {
+    return this.withoutMetaTools(entries).map((entry) => {
+      const name = entry.name as string;
+      const meta = metas.get(name);
+      if (!meta || isEager(meta, eager)) {
+        return entry;
+      }
+      const prev = (entry._meta as Record<string, unknown> | undefined) ?? {};
+      return {
+        ...entry,
+        _meta: { ...prev, [META_DEFER_LOADING]: true },
+      };
+    });
+  }
+
+  private applyLazy(
+    entries: Array<Record<string, unknown>>,
+    metas: Map<string, ToolMetadata>,
+    eager: Parameters<typeof isEager>[1],
+  ): Array<Record<string, unknown>> {
+    return entries.filter((entry) => {
+      const name = entry.name as string;
+      if (this.metaToolNames.has(name)) return true; // always include meta-tools under lazy
+      const meta = metas.get(name);
+      if (!meta) return true;
+      return isEager(meta, eager);
+    });
+  }
+
+  private withoutMetaTools(
+    entries: Array<Record<string, unknown>>,
+  ): Array<Record<string, unknown>> {
+    return entries.filter((e) => !this.metaToolNames.has(e.name as string));
+  }
+
+  // ---- Configuration introspection ----
+
+  private lazyHint():
+    | { indexToolName?: string; schemaToolName?: string; maxBatchSize?: number }
+    | undefined {
+    if (typeof this.configured !== 'object' || this.configured.kind !== 'lazy') return undefined;
+    return this.configured;
+  }
+
+  private canResolveToLazy(): boolean {
+    // Resolver form: we can't know statically what it returns. Register to be safe.
+    if (typeof this.configured === 'function') return true;
+    return this.configured.kind === 'lazy';
+  }
+
+  private canResolveToSearch(): boolean {
+    if (typeof this.configured === 'function') return true;
+    return this.configured.kind === 'search';
+  }
+
+  // ---- Registration ----
+
+  private registerMetaTools(): void {
+    const { indexToolName, schemaToolName } = this.metaToolConfig;
+    this.metaToolNames.add(indexToolName);
+    this.metaToolNames.add(schemaToolName);
+
+    const indexTool: RegisteredTool = {
+      name: indexToolName,
+      description: DEFAULT_LIST_TOOL_DESCRIPTION,
+      parameters: listAvailableToolsSchema,
+      exposure: 'eager',
+      methodName: 'handleListAvailableTools',
+      target: ExposureService as unknown as abstract new (...args: unknown[]) => unknown,
+      instance: this as unknown as Record<string, unknown>,
+    };
+
+    const schemaTool: RegisteredTool = {
+      name: schemaToolName,
+      description: DEFAULT_SCHEMA_TOOL_DESCRIPTION,
+      parameters: getToolSchemaSchema,
+      exposure: 'eager',
+      methodName: 'handleGetToolSchema',
+      target: ExposureService as unknown as abstract new (...args: unknown[]) => unknown,
+      instance: this as unknown as Record<string, unknown>,
+    };
+
+    this.registry.registerTool(indexTool);
+    this.registry.registerTool(schemaTool);
+  }
+
+  // ---- Validation ----
+
+  private validateNameCollisions(): void {
+    const { indexToolName, schemaToolName } = this.metaToolConfig;
+    for (const name of [indexToolName, schemaToolName]) {
+      if (this.registry.getTool(name)) {
+        throw new Error(
+          `ExposureService: meta-tool name '${name}' collides with an existing tool. Set exposure.indexToolName / schemaToolName to a unique value.`,
+        );
+      }
+    }
+  }
+
+  private validateSearchReachable(): void {
+    if (!this.canResolveToSearch()) return;
+    const strategy = typeof this.configured === 'function' ? undefined : this.configured;
+
+    // Only static search strategies can be exhaustively validated at bootstrap.
+    if (!strategy || strategy.kind !== 'search') return;
+
+    const tools = this.registry.getAllTools().filter((t) => !this.metaToolNames.has(t.name));
+    const anyEager = tools.some((t) => isEager(t, strategy.eager));
+    if (tools.length > 0 && !anyEager) {
+      const behavior = strategy.onAllDeferred ?? 'throw';
+      const message = `ExposureService: kind 'search' resolved zero eager tools. Anthropic requires at least one non-deferred tool per request. Add 'eager' tags to your core tools or set exposure.onAllDeferred to override.`;
+      if (behavior === 'throw') {
+        throw new Error(message);
+      }
+      if (behavior === 'warn') {
+        this.logger.warn(message);
+      }
+      // 'promoteFirst' is handled at transform time
+    }
+  }
+}

--- a/packages/server/src/exposure/exposure.service.ts
+++ b/packages/server/src/exposure/exposure.service.ts
@@ -2,11 +2,14 @@ import {
   type ClientContext,
   type ExposureStrategy,
   type ExposureStrategyResolver,
+  type LazyStrategyOptions,
   MCP_OPTIONS,
   META_DEFER_LOADING,
   type McpModuleOptions,
   RESOLVER_KINDS,
+  type ToolListEntry,
   type ToolMetadata,
+  type ToolSelector,
 } from '@nest-mcp/common';
 import { Inject, Injectable, Logger, type OnApplicationBootstrap } from '@nestjs/common';
 import { McpRegistryService } from '../discovery/registry.service';
@@ -106,10 +109,10 @@ export class ExposureService implements OnApplicationBootstrap {
    * @param ctx     - Client context used to resolve the strategy.
    */
   applyStrategy(
-    entries: Array<Record<string, unknown>>,
+    entries: ToolListEntry[],
     metas: Map<string, ToolMetadata>,
     ctx: ClientContext,
-  ): Array<Record<string, unknown>> {
+  ): ToolListEntry[] {
     const strategy = this.resolveForClient(ctx);
 
     switch (strategy.kind) {
@@ -123,6 +126,12 @@ export class ExposureService implements OnApplicationBootstrap {
         throw new Error(
           "ExposureStrategy kind 'typed-api' is reserved and not implemented in this release",
         );
+      default: {
+        // Exhaustiveness guard — adding a new `kind` to ExposureStrategy
+        // becomes a compile error here instead of a silent fallthrough.
+        const _exhaustive: never = strategy;
+        return _exhaustive;
+      }
     }
   }
 
@@ -150,49 +159,42 @@ export class ExposureService implements OnApplicationBootstrap {
   // ---- Strategy implementations ----
 
   private applySearch(
-    entries: Array<Record<string, unknown>>,
+    entries: ToolListEntry[],
     metas: Map<string, ToolMetadata>,
-    eager: Parameters<typeof isEager>[1],
-  ): Array<Record<string, unknown>> {
+    eager: ToolSelector | undefined,
+  ): ToolListEntry[] {
     return this.withoutMetaTools(entries).map((entry) => {
-      const name = entry.name as string;
-      const meta = metas.get(name);
+      const meta = metas.get(entry.name);
       if (!meta || isEager(meta, eager)) {
         return entry;
       }
-      const prev = (entry._meta as Record<string, unknown> | undefined) ?? {};
       return {
         ...entry,
-        _meta: { ...prev, [META_DEFER_LOADING]: true },
+        _meta: { ...(entry._meta ?? {}), [META_DEFER_LOADING]: true },
       };
     });
   }
 
   private applyLazy(
-    entries: Array<Record<string, unknown>>,
+    entries: ToolListEntry[],
     metas: Map<string, ToolMetadata>,
-    eager: Parameters<typeof isEager>[1],
-  ): Array<Record<string, unknown>> {
+    eager: ToolSelector | undefined,
+  ): ToolListEntry[] {
     return entries.filter((entry) => {
-      const name = entry.name as string;
-      if (this.metaToolNames.has(name)) return true; // always include meta-tools under lazy
-      const meta = metas.get(name);
+      if (this.metaToolNames.has(entry.name)) return true;
+      const meta = metas.get(entry.name);
       if (!meta) return true;
       return isEager(meta, eager);
     });
   }
 
-  private withoutMetaTools(
-    entries: Array<Record<string, unknown>>,
-  ): Array<Record<string, unknown>> {
-    return entries.filter((e) => !this.metaToolNames.has(e.name as string));
+  private withoutMetaTools(entries: ToolListEntry[]): ToolListEntry[] {
+    return entries.filter((e) => !this.metaToolNames.has(e.name));
   }
 
   // ---- Configuration introspection ----
 
-  private lazyHint():
-    | { indexToolName?: string; schemaToolName?: string; maxBatchSize?: number }
-    | undefined {
+  private lazyHint(): LazyStrategyOptions | undefined {
     if (typeof this.configured !== 'object' || this.configured.kind !== 'lazy') return undefined;
     return this.configured;
   }
@@ -244,28 +246,31 @@ export class ExposureService implements OnApplicationBootstrap {
     this.metaToolNames.add(indexToolName);
     this.metaToolNames.add(schemaToolName);
 
-    const indexTool: RegisteredTool = {
+    // Single `as` cast rather than `as unknown as` laundering — `ToolMetadata.target`
+    // uses `never[]` in the parameter position (see its definition), so any concrete
+    // constructor is structurally assignable with one hop.
+    const target = ExposureService as abstract new (...args: never[]) => unknown;
+    const instance = this as unknown as Record<string, unknown>;
+
+    this.registry.registerTool({
       name: indexToolName,
       description: DEFAULT_LIST_TOOL_DESCRIPTION,
       parameters: listAvailableToolsSchema,
       exposure: 'eager',
       methodName: 'handleListAvailableTools',
-      target: ExposureService as unknown as abstract new (...args: unknown[]) => unknown,
-      instance: this as unknown as Record<string, unknown>,
-    };
+      target,
+      instance,
+    });
 
-    const schemaTool: RegisteredTool = {
+    this.registry.registerTool({
       name: schemaToolName,
       description: DEFAULT_SCHEMA_TOOL_DESCRIPTION,
       parameters: getToolSchemaSchema,
       exposure: 'eager',
       methodName: 'handleGetToolSchema',
-      target: ExposureService as unknown as abstract new (...args: unknown[]) => unknown,
-      instance: this as unknown as Record<string, unknown>,
-    };
-
-    this.registry.registerTool(indexTool);
-    this.registry.registerTool(schemaTool);
+      target,
+      instance,
+    });
   }
 
   // ---- Validation ----
@@ -282,24 +287,23 @@ export class ExposureService implements OnApplicationBootstrap {
   }
 
   private validateSearchReachable(): void {
-    if (!this.canResolveToSearch()) return;
-    const strategy = typeof this.configured === 'function' ? undefined : this.configured;
+    // Resolver-based strategies can't be statically validated — their eager
+    // selector depends on runtime client context. Validation runs implicitly
+    // at request time (Anthropic's API rejects all-deferred requests).
+    if (typeof this.configured === 'function') return;
+    if (this.configured.kind !== 'search') return;
 
-    // Only static search strategies can be exhaustively validated at bootstrap.
-    if (!strategy || strategy.kind !== 'search') return;
-
+    const strategy = this.configured;
     const tools = this.registry.getAllTools().filter((t) => !this.metaToolNames.has(t.name));
+    if (tools.length === 0) return;
+
     const anyEager = tools.some((t) => isEager(t, strategy.eager));
-    if (tools.length > 0 && !anyEager) {
-      const behavior = strategy.onAllDeferred ?? 'throw';
-      const message = `ExposureService: kind 'search' resolved zero eager tools. Anthropic requires at least one non-deferred tool per request. Add 'eager' tags to your core tools or set exposure.onAllDeferred to override.`;
-      if (behavior === 'throw') {
-        throw new Error(message);
-      }
-      if (behavior === 'warn') {
-        this.logger.warn(message);
-      }
-      // 'promoteFirst' is handled at transform time
-    }
+    if (anyEager) return;
+
+    const behavior = strategy.onAllDeferred ?? 'throw';
+    const message = `ExposureService: kind 'search' resolved zero eager tools. Anthropic requires at least one non-deferred tool per request. Add 'eager' tags to your core tools or set exposure.onAllDeferred to override.`;
+    if (behavior === 'throw') throw new Error(message);
+    if (behavior === 'warn') this.logger.warn(message);
+    // 'promoteFirst' is handled at transform time.
   }
 }

--- a/packages/server/src/exposure/meta-tools/get-tool-schema.ts
+++ b/packages/server/src/exposure/meta-tools/get-tool-schema.ts
@@ -1,0 +1,69 @@
+import { type ToolMetadata, zodToJsonSchema } from '@nest-mcp/common';
+import { z } from 'zod';
+
+export const DEFAULT_SCHEMA_TOOL_NAME = 'get_tool_schema';
+
+export const DEFAULT_SCHEMA_TOOL_DESCRIPTION = [
+  'Fetch full JSON schemas for one or more tools discovered via `list_available_tools`.',
+  'Batch multiple names in a single call to save round-trips.',
+  'Unknown names are returned in `notFound`, not as errors.',
+].join(' ');
+
+export const getToolSchemaSchema = z.object({
+  names: z
+    .array(z.string())
+    .min(1)
+    .describe('Tool names to fetch schemas for. Batch to save round-trips.'),
+});
+
+export type GetToolSchemaArgs = z.infer<typeof getToolSchemaSchema>;
+
+export interface ToolSchemaEntry {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+}
+
+export interface GetToolSchemaResult {
+  schemas: ToolSchemaEntry[];
+  notFound: string[];
+}
+
+/**
+ * Execute the schema fetch. Pure function — given the full tool pool and a
+ * list of names, returns resolved schemas + unresolved names.
+ */
+export function getToolSchema(
+  pool: Map<string, ToolMetadata>,
+  args: GetToolSchemaArgs,
+  maxBatchSize: number,
+): GetToolSchemaResult {
+  const requested = args.names.slice(0, maxBatchSize);
+  const schemas: ToolSchemaEntry[] = [];
+  const notFound: string[] = [];
+
+  for (const name of requested) {
+    const meta = pool.get(name);
+    if (!meta) {
+      notFound.push(name);
+      continue;
+    }
+    const inputSchema = meta.parameters
+      ? (zodToJsonSchema(meta.parameters) as Record<string, unknown>)
+      : (meta.inputSchema ?? { type: 'object' });
+    schemas.push({
+      name: meta.name,
+      description: meta.description,
+      inputSchema,
+      ...(meta.outputSchema
+        ? { outputSchema: zodToJsonSchema(meta.outputSchema) as Record<string, unknown> }
+        : meta.rawOutputSchema
+          ? { outputSchema: meta.rawOutputSchema }
+          : {}),
+      ...(meta.annotations ? { annotations: meta.annotations as Record<string, unknown> } : {}),
+    });
+  }
+  return { schemas, notFound };
+}

--- a/packages/server/src/exposure/meta-tools/get-tool-schema.ts
+++ b/packages/server/src/exposure/meta-tools/get-tool-schema.ts
@@ -1,4 +1,4 @@
-import { type ToolMetadata, zodToJsonSchema } from '@nest-mcp/common';
+import { type ToolAnnotations, type ToolMetadata, zodToJsonSchema } from '@nest-mcp/common';
 import { z } from 'zod';
 
 export const DEFAULT_SCHEMA_TOOL_NAME = 'get_tool_schema';
@@ -23,7 +23,7 @@ export interface ToolSchemaEntry {
   description: string;
   inputSchema: Record<string, unknown>;
   outputSchema?: Record<string, unknown>;
-  annotations?: Record<string, unknown>;
+  annotations?: ToolAnnotations;
 }
 
 export interface GetToolSchemaResult {
@@ -62,7 +62,7 @@ export function getToolSchema(
         : meta.rawOutputSchema
           ? { outputSchema: meta.rawOutputSchema }
           : {}),
-      ...(meta.annotations ? { annotations: meta.annotations as Record<string, unknown> } : {}),
+      ...(meta.annotations ? { annotations: meta.annotations } : {}),
     });
   }
   return { schemas, notFound };

--- a/packages/server/src/exposure/meta-tools/list-available-tools.ts
+++ b/packages/server/src/exposure/meta-tools/list-available-tools.ts
@@ -1,0 +1,81 @@
+import { paginate } from '@nest-mcp/common';
+import type { ToolMetadata } from '@nest-mcp/common';
+import { z } from 'zod';
+
+export const DEFAULT_LIST_TOOL_NAME = 'list_available_tools';
+
+export const DEFAULT_LIST_TOOL_DESCRIPTION = [
+  'Returns a paginated index of available tools (name, short description, tags).',
+  'Does not include JSON schemas — call `get_tool_schema` once you pick a tool.',
+  'Use this to discover tools without bloating the conversation with full schemas.',
+].join(' ');
+
+export const listAvailableToolsSchema = z.object({
+  query: z
+    .string()
+    .optional()
+    .describe('Case-insensitive substring match over tool name and description.'),
+  tags: z
+    .array(z.string())
+    .optional()
+    .describe('Restrict results to tools that carry ALL of these tags.'),
+  cursor: z.string().optional().describe('Pagination cursor returned by a previous call.'),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(200)
+    .optional()
+    .describe('Maximum tools to return. Default 50, max 200.'),
+});
+
+export type ListAvailableToolsArgs = z.infer<typeof listAvailableToolsSchema>;
+
+export interface ListAvailableToolsResult {
+  tools: Array<{ name: string; description: string; tags?: string[] }>;
+  nextCursor?: string;
+  total?: number;
+}
+
+export interface IndexEntry {
+  meta: ToolMetadata;
+  oneLineDescription: string;
+}
+
+/**
+ * Execute the index lookup. Pure function — takes the eligible tools and
+ * query params, returns the paginated response.
+ */
+export function listAvailableTools(
+  entries: IndexEntry[],
+  args: ListAvailableToolsArgs,
+): ListAvailableToolsResult {
+  const { query, tags, cursor, limit = 50 } = args;
+
+  let filtered = entries;
+  if (tags?.length) {
+    filtered = filtered.filter((e) => {
+      const have = e.meta.tags ?? [];
+      return tags.every((t) => have.includes(t));
+    });
+  }
+  if (query) {
+    const q = query.toLowerCase();
+    filtered = filtered.filter(
+      (e) => e.meta.name.toLowerCase().includes(q) || e.meta.description.toLowerCase().includes(q),
+    );
+  }
+
+  const mapped = filtered.map((e) => ({
+    name: e.meta.name,
+    description: e.oneLineDescription,
+    ...(e.meta.tags?.length ? { tags: e.meta.tags } : {}),
+  }));
+
+  const page = paginate(mapped, cursor, limit);
+  return {
+    tools: page.items,
+    ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+    total: filtered.length,
+  };
+}

--- a/packages/server/src/exposure/selector.spec.ts
+++ b/packages/server/src/exposure/selector.spec.ts
@@ -1,0 +1,59 @@
+import type { ToolMetadata } from '@nest-mcp/common';
+import { describe, expect, it } from 'vitest';
+import { isEager, matchesSelector } from './selector';
+
+function meta(overrides: Partial<ToolMetadata> = {}): ToolMetadata {
+  return {
+    name: 'tool',
+    description: 'desc',
+    methodName: 'fn',
+    target: class {} as unknown as abstract new (...args: unknown[]) => unknown,
+    ...overrides,
+  };
+}
+
+describe('matchesSelector', () => {
+  it('array form matches on tool name', () => {
+    expect(matchesSelector(meta({ name: 'a' }), ['a', 'b'])).toBe(true);
+    expect(matchesSelector(meta({ name: 'c' }), ['a', 'b'])).toBe(false);
+  });
+
+  it('tags form matches when any tag overlaps', () => {
+    expect(matchesSelector(meta({ tags: ['core', 'fast'] }), { tags: ['core'] })).toBe(true);
+    expect(matchesSelector(meta({ tags: ['slow'] }), { tags: ['core'] })).toBe(false);
+  });
+
+  it('tags form is false when tool has no tags', () => {
+    expect(matchesSelector(meta(), { tags: ['core'] })).toBe(false);
+  });
+
+  it('function form delegates to the predicate', () => {
+    expect(matchesSelector(meta({ name: 'x' }), (m) => m.name.startsWith('x'))).toBe(true);
+    expect(matchesSelector(meta({ name: 'y' }), (m) => m.name.startsWith('x'))).toBe(false);
+  });
+});
+
+describe('isEager', () => {
+  it('returns true when per-tool exposure is "eager" regardless of selector', () => {
+    expect(isEager(meta({ exposure: 'eager' }), { tags: ['never-matches'] })).toBe(true);
+  });
+
+  it('returns false when per-tool exposure is "deferred" regardless of selector', () => {
+    const selector = ['tool'] as const;
+    expect(isEager(meta({ exposure: 'deferred' }), [...selector])).toBe(false);
+  });
+
+  it('falls back to selector when exposure is "auto"', () => {
+    expect(isEager(meta({ exposure: 'auto', tags: ['core'] }), { tags: ['core'] })).toBe(true);
+    expect(isEager(meta({ exposure: 'auto', tags: [] }), { tags: ['core'] })).toBe(false);
+  });
+
+  it('defaults to eager when no selector is supplied and no override is set', () => {
+    expect(isEager(meta(), undefined)).toBe(true);
+  });
+
+  it('treats missing exposure as "auto"', () => {
+    expect(isEager(meta({ tags: ['core'] }), { tags: ['core'] })).toBe(true);
+    expect(isEager(meta({ tags: ['other'] }), { tags: ['core'] })).toBe(false);
+  });
+});

--- a/packages/server/src/exposure/selector.spec.ts
+++ b/packages/server/src/exposure/selector.spec.ts
@@ -7,7 +7,7 @@ function meta(overrides: Partial<ToolMetadata> = {}): ToolMetadata {
     name: 'tool',
     description: 'desc',
     methodName: 'fn',
-    target: class {} as unknown as abstract new (...args: unknown[]) => unknown,
+    target: class {},
     ...overrides,
   };
 }

--- a/packages/server/src/exposure/selector.ts
+++ b/packages/server/src/exposure/selector.ts
@@ -1,0 +1,33 @@
+import type { ToolMetadata, ToolSelector } from '@nest-mcp/common';
+
+/**
+ * Evaluate a {@link ToolSelector} against a tool's metadata.
+ *
+ * - Array form: inclusion test against the tool name.
+ * - `{ tags }` form: true if the tool has any of the given tags.
+ * - Function form: delegated to the predicate.
+ */
+export function matchesSelector(meta: ToolMetadata, selector: ToolSelector): boolean {
+  if (typeof selector === 'function') {
+    return selector(meta);
+  }
+  if (Array.isArray(selector)) {
+    return selector.includes(meta.name);
+  }
+  const toolTags = meta.tags ?? [];
+  return selector.tags.some((tag) => toolTags.includes(tag));
+}
+
+/**
+ * Decide whether a tool is "eager" under a given strategy's selector.
+ * Per-tool `exposure` overrides win over the module selector:
+ *  - `exposure: 'eager'`    → always eager
+ *  - `exposure: 'deferred'` → never eager
+ *  - `exposure: 'auto'` or unset → consult the selector (if none supplied, default to eager)
+ */
+export function isEager(meta: ToolMetadata, selector: ToolSelector | undefined): boolean {
+  if (meta.exposure === 'eager') return true;
+  if (meta.exposure === 'deferred') return false;
+  if (!selector) return true;
+  return matchesSelector(meta, selector);
+}

--- a/packages/server/src/mcp.module.ts
+++ b/packages/server/src/mcp.module.ts
@@ -33,6 +33,9 @@ import { McpExecutorService } from './execution/executor.service';
 import { ExecutionPipelineService } from './execution/pipeline.service';
 import { McpRequestContextService } from './execution/request-context.service';
 
+// Exposure
+import { ExposureService } from './exposure/exposure.service';
+
 import { createSseController } from './transport/sse/sse.controller.factory';
 import { SseService } from './transport/sse/sse.service';
 import { StdioService } from './transport/stdio/stdio.service';
@@ -93,6 +96,7 @@ export class McpModule {
       McpRegistryService,
       McpScannerService,
       McpExecutorService,
+      ExposureService,
       ExecutionPipelineService,
       McpRequestContextService,
       McpContextFactory,
@@ -141,6 +145,7 @@ export class McpModule {
       exports: [
         McpRegistryService,
         McpExecutorService,
+        ExposureService,
         ExecutionPipelineService,
         McpRequestContextService,
         McpToolBuilder,
@@ -166,6 +171,7 @@ export class McpModule {
       McpRegistryService,
       McpScannerService,
       McpExecutorService,
+      ExposureService,
       ExecutionPipelineService,
       McpRequestContextService,
       McpContextFactory,
@@ -215,6 +221,7 @@ export class McpModule {
       exports: [
         McpRegistryService,
         McpExecutorService,
+        ExposureService,
         ExecutionPipelineService,
         McpRequestContextService,
         McpToolBuilder,

--- a/packages/server/src/testing/create-test-app.ts
+++ b/packages/server/src/testing/create-test-app.ts
@@ -3,6 +3,7 @@ import type {
   PromptGetResult,
   ResourceReadResult,
   ToolCallResult,
+  ToolListEntry,
 } from '@nest-mcp/common';
 import { McpTransportType } from '@nest-mcp/common';
 import type { DynamicModule, ForwardReference, Provider, Type } from '@nestjs/common';
@@ -15,7 +16,7 @@ import { McpExecutorService } from '../execution/executor.service';
 export interface McpTestApp {
   callTool(name: string, args?: Record<string, unknown>): Promise<ToolCallResult>;
   readResource(uri: string): Promise<ResourceReadResult>;
-  listTools(): Promise<PaginatedResult<Record<string, unknown>>>;
+  listTools(): Promise<PaginatedResult<ToolListEntry>>;
   listResources(): Promise<PaginatedResult<Record<string, unknown>>>;
   listPrompts(): Promise<PaginatedResult<Record<string, unknown>>>;
   getPrompt(name: string, args?: Record<string, unknown>): Promise<PromptGetResult>;

--- a/packages/server/src/transport/register-handlers.spec.ts
+++ b/packages/server/src/transport/register-handlers.spec.ts
@@ -446,7 +446,10 @@ describe('registerHandlers', () => {
     const handler = listToolsCall?.[1];
     const result = await handler({ method: 'tools/list', params: { cursor: 'abc123' } });
 
-    expect(mockPipeline.listTools).toHaveBeenCalledWith('abc123');
+    expect(mockPipeline.listTools).toHaveBeenCalledWith(
+      'abc123',
+      expect.objectContaining({ transport: ctx.transport }),
+    );
     expect(result).toEqual({ tools: [{ name: 'tool-a' }], nextCursor: 'abc123' });
   });
 

--- a/packages/server/src/transport/register-handlers.ts
+++ b/packages/server/src/transport/register-handlers.ts
@@ -22,6 +22,7 @@ import type {
   McpProgress,
   ToolContent,
 } from '@nest-mcp/common';
+import { buildClientContext } from '@nest-mcp/common';
 import { z } from 'zod';
 import type {
   McpRegistryService,
@@ -102,7 +103,7 @@ export function registerHandlers(
     registerPromptOnServer(server, prompt, pipeline, ctx);
   }
   registerCancellationHandler(server);
-  registerListHandlers(server, pipeline, registry, options);
+  registerListHandlers(server, pipeline, registry, options, ctx);
   registerCompletionHandler(server, pipeline, registry, options);
   if (subscriptionManager) {
     registerSubscriptionHandlers(server, subscriptionManager, ctx);
@@ -336,10 +337,15 @@ function registerListHandlers(
   pipeline: ExecutionPipelineService,
   registry: McpRegistryService,
   options: McpModuleOptions,
+  ctx: McpExecutionContext,
 ): void {
   server.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
     const cursor = request.params?.cursor;
-    const result = await pipeline.listTools(cursor);
+    const clientContext = buildClientContext({
+      transport: ctx.transport,
+      request: ctx.request,
+    });
+    const result = await pipeline.listTools(cursor, clientContext);
     return { tools: result.items, ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}) };
   });
 


### PR DESCRIPTION
## Summary

- Add `McpModuleOptions.exposure` so large tool catalogs can avoid bloating the initial prompt.
- Four strategy kinds: `eager` (current behavior), `search` (Anthropic Tool Search Tool), `lazy` (vendor-neutral on-demand discovery), `typed-api` (reserved for Code Mode).
- Per-client tiering via optional resolver function + ship `preferSearchElseLazy` preset. Capability detection uses the `anthropic-beta` header — no model regex.

## How it works

- `kind: 'search'` annotates deferred tools with `_meta.defer_loading: true` so Anthropic-aware clients route them through the Tool Search Tool beta (`advanced-tool-use-2025-11-20`). No protocol extensions.
- `kind: 'lazy'` ships two synthesized meta-tools — `list_available_tools` (paginated index, no schemas) and `get_tool_schema` (batched schema fetch) — that any MCP client can call. Deferred tools are filtered out of `tools/list` so only the eager subset + the meta-tools appear up front.
- `@Tool({ tags, exposure })` accept new optional fields (`'eager' | 'deferred' | 'auto'`). Decorator override beats module policy.
- All new fields are optional; existing servers behave unchanged.

## Test plan

- [x] `pnpm -r test` — 1,537 tests pass across common/server/gateway/client
- [x] New coverage: `ExposureService` (strategy resolution, all three runtime kinds, meta-tool registration ordering, bootstrap validators); `list_available_tools` + `get_tool_schema` pure functions; `selector` (`isEager`, `matchesSelector`); `buildClientContext` (header parsing); `clientSupports.search` (beta header detection); `preferSearchElseLazy` (tiering)
- [x] `pnpm lint` — clean (3 pre-existing complexity warnings unchanged)
- [x] `pnpm build` — clean across all packages

## Follow-ups not in this PR

- `kind: 'typed-api'` throws `"not implemented"` at resolve time; Code Mode lands in a later PR once there are clients to target.
- `clientInfo` / `model` fields on `ClientContext` are defined but not yet populated by the transport — the `anthropic-beta` header is the only live signal in this PR.
- Gateway-side integration of the exposure transform for aggregated upstream catalogs is straightforward (`UpstreamManagerService` already builds `ToolMeta[]`) but out of scope here.