### PR TITLE
fix(client): avoid invoking accessors during notification scan

### DIFF
--- a/.changeset/fix-client-notification-descriptor-scan.md
+++ b/.changeset/fix-client-notification-descriptor-scan.md
@@ -1,0 +1,5 @@
+---
+"@nest-mcp/client": patch
+---
+
+Avoid invoking provider prototype accessors while wiring `@OnMcpNotification` handlers. The bootstrap scanner now inspects property descriptors and only reads method values, preventing Nest provider getters from throwing during app startup.

--- a/packages/client/src/mcp-client.module.spec.ts
+++ b/packages/client/src/mcp-client.module.spec.ts
@@ -468,8 +468,11 @@ describe('McpClientBootstrap notification wiring', () => {
     expect(onNotificationFn).not.toHaveBeenCalled();
   });
 
-  it('skips non-function prototype own properties without throwing', async () => {
+  it('skips non-function prototype own properties without invoking accessors', async () => {
     const onNotificationFn = vi.fn();
+    const accessor = vi.fn(() => {
+      throw new Error('getter should not be invoked while scanning handlers');
+    });
     const clientA = {
       name: 'server-a',
       connect: vi.fn().mockResolvedValue(undefined),
@@ -480,14 +483,12 @@ describe('McpClientBootstrap notification wiring', () => {
 
     // Simulates providers registered with `useValue: {}` (plain object) or
     // classes whose prototype exposes non-function own properties via
-    // accessors — `Reflect.getMetadata` throws TypeError on non-object targets.
+    // accessors. The scan must not invoke getters while looking for methods.
     class HandlerWithAccessor {
       handleNotification() {}
     }
     Object.defineProperty(HandlerWithAccessor.prototype, 'nonFunctionProp', {
-      get() {
-        return null;
-      },
+      get: accessor,
       enumerable: false,
       configurable: true,
     });
@@ -518,5 +519,6 @@ describe('McpClientBootstrap notification wiring', () => {
       'notifications/tools/list_changed',
       expect.any(Function),
     );
+    expect(accessor).not.toHaveBeenCalled();
   });
 });

--- a/packages/client/src/mcp-client.module.ts
+++ b/packages/client/src/mcp-client.module.ts
@@ -184,11 +184,8 @@ export class McpClientBootstrap implements OnApplicationBootstrap, OnApplication
         );
 
         for (const methodName of methodNames) {
-          // Prototype own-property names can include non-function values
-          // (e.g. `Object.prototype.__proto__` on `useValue: {}` providers, or
-          // accessor properties on library classes). `Reflect.getMetadata`
-          // throws TypeError on non-object targets, so skip non-functions.
-          const method = prototype[methodName];
+          const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
+          const method = descriptor?.value;
           if (typeof method !== 'function') continue;
 
           // NestJS SetMetadata stores metadata on the descriptor.value (the method
@@ -210,9 +207,7 @@ export class McpClientBootstrap implements OnApplicationBootstrap, OnApplication
             continue;
           }
 
-          const boundHandler = (
-            instance as Record<string, (...args: unknown[]) => void | Promise<void>>
-          )[methodName].bind(instance);
+          const boundHandler = method.bind(instance);
           client.onNotification(metadata.method, boundHandler);
           wiredCount++;
         }


### PR DESCRIPTION
## Summary
- inspect prototype property descriptors while wiring @OnMcpNotification handlers
- avoid invoking provider getters during bootstrap scanning
- add a regression test that fails if scanning touches accessors
- add a Changesets patch entry for @nest-mcp/client

## Verification
- pnpm --filter @nest-mcp/client test
- pnpm --filter @nest-mcp/client typecheck
- pnpm --filter @nest-mcp/client build
- pnpm --filter @nest-mcp/client lint
- pnpm changeset status --since main
