### PR TITLE
feat: OAuth 2.1 transport hardening for streamable HTTP

### DIFF
--- a/.changeset/oauth-transport-hardening.md
+++ b/.changeset/oauth-transport-hardening.md
@@ -1,0 +1,61 @@
+---
+'@nest-mcp/server': minor
+'@nest-mcp/common': minor
+---
+
+feat: OAuth/transport hardening for the streamable HTTP transport and `McpAuthModule`
+
+**Behavioral callout — per-request auth context.** Handler and guard contexts
+on the streamable HTTP transport are now rebuilt per request from the SDK's
+`RequestHandlerExtra`: `ctx.request` is the per-request `RequestInfo`
+(`{ headers }`) instead of the session's *initialize* `IncomingMessage`.
+Code reading `ctx.request.url` / `ctx.request.method` must migrate to header
+inspection (or a controller guard); previously those values were stale
+captures from the first request of the session anyway. `ctx.authInfo` and
+`ctx.user` are likewise populated from the verified per-request identity.
+
+Streamable HTTP transport:
+
+- `transportOptions.streamableHttp.oauth` — opt-in bearer-token gate
+  (`enabled`, `required`, `resourceMetadataUrl`, `bindSessionToUser`).
+  Unauthorized requests get HTTP 401 with a `WWW-Authenticate: Bearer ...
+  resource_metadata="..."` challenge (RFC 9728 discovery flow). Tokens are
+  verified via the overridable `MCP_BEARER_TOKEN_VERIFIER` provider
+  (`BearerTokenVerifier` interface, default `JwtBearerTokenVerifier`).
+- Session binding: when oauth is enabled, stateful sessions are bound to the
+  principal that initialized them; requests from another principal get 403.
+  Only active with `oauth.enabled` — existing stateful servers are unaffected.
+- DNS-rebinding options forwarded to the SDK transport: `allowedHosts`,
+  `allowedOrigins`, `enableDnsRebindingProtection`.
+- `controllerGuards` / `controllerDecorators` applied to the generated
+  controller (static even with `forRootAsync`, like `endpoint`).
+- `filterListsByScopes` McpModule option: `tools/resources/templates/prompts`
+  list results hide items whose required scopes the caller's token lacks.
+
+`McpAuthModule` / OAuth server:
+
+- `McpAuthModule.forRootAsync({ imports?, serverUrl?, useFactory, inject? })`
+  with the same `jwtSecret` validation as `forRoot`; the well-known controller
+  now constructor-injects `MCP_AUTH_OPTIONS`. `MCP_OAUTH_STORE` is provided
+  via a factory in both variants, so a store supplied through options/DI wins
+  over the in-memory default.
+- Well-known compliance: `introspection_endpoint` (+
+  `introspection_endpoint_auth_methods_supported`,
+  `revocation_endpoint_auth_methods_supported`) in the RFC 8414 document, and
+  path-insertion wildcard routes for both
+  `/.well-known/oauth-authorization-server/*` and
+  `/.well-known/oauth-protected-resource/*` (Nest 10 and 11 wildcard syntax
+  both supported).
+- RFC 8707 audience binding: access tokens carry
+  `aud = resource ?? audience ?? 'mcp-client'`; `validateToken` still does not
+  enforce `aud` (non-breaking). Access tokens now also carry a `jti`, making
+  them individually revocable.
+- Optional `IOAuthStore.recordIssuedToken(rec)` hook invoked for both tokens
+  on the initial grant and on refresh, enabling issued-token tracking and
+  refresh-chain revocation; revoked refresh `jti`s are rejected before reuse.
+- New exports: `resolveGuard`, `McpAuthModuleAsyncOptions`,
+  `IssuedTokenRecord` (plus the new transport option types via
+  `@nest-mcp/common`).
+
+Requires `@modelcontextprotocol/sdk` peer `^1.26.0` (per-request `authInfo`
+and `requestInfo` on `RequestHandlerExtra`).

--- a/.changeset/oauth-transport-hardening.md
+++ b/.changeset/oauth-transport-hardening.md
@@ -59,3 +59,7 @@ Streamable HTTP transport:
 
 Requires `@modelcontextprotocol/sdk` peer `^1.26.0` (per-request `authInfo`
 and `requestInfo` on `RequestHandlerExtra`).
+
+Fix: refresh tokens now carry the `scope` claim, so access tokens re-minted by
+the `refresh_token` grant preserve the originally granted scopes (previously
+they came back scope-less and failed every scope check).

--- a/.changeset/sdk-peer-bump-client-gateway.md
+++ b/.changeset/sdk-peer-bump-client-gateway.md
@@ -1,0 +1,6 @@
+---
+'@nest-mcp/client': patch
+'@nest-mcp/gateway': patch
+---
+
+chore: require `@modelcontextprotocol/sdk` peer `^1.26.0`, aligning with `@nest-mcp/server` (which needs the per-request `authInfo`/`requestInfo` surface introduced there).

--- a/docs/server/auth.md
+++ b/docs/server/auth.md
@@ -34,6 +34,32 @@ import { McpTransportType } from '@nest-mcp/common';
 export class AppModule {}
 ```
 
+## Async Setup (`forRootAsync`)
+
+Use `McpAuthModule.forRootAsync` when options come from DI (e.g.
+`ConfigService`):
+
+```typescript
+McpAuthModule.forRootAsync({
+  imports: [ConfigModule],
+  // Static: controllers are created at module-definition time, so the base
+  // path for /authorize, /token, ... must be known up front.
+  serverUrl: 'https://my-server.example.com',
+  inject: [ConfigService],
+  useFactory: (config: ConfigService) => ({
+    jwtSecret: config.getOrThrow('JWT_SECRET'),
+    serverUrl: config.getOrThrow('SERVER_URL'),
+    validateUser: async (req) => ({ id: 'user-1' }),
+  }),
+}),
+```
+
+The factory result is validated the same way as `forRoot` (`jwtSecret` must
+be at least 32 characters; validation runs when the factory resolves). The
+static `serverUrl` only shapes controller paths — everything else, including
+the `serverUrl` used in metadata documents and token claims, comes from the
+resolved options.
+
 ## McpAuthModuleOptions
 
 | Option | Type | Required | Description |
@@ -63,9 +89,35 @@ When `McpAuthModule.forRoot` is imported, the following HTTP endpoints are regis
 | POST | `/revoke` | Token revocation |
 | POST | `/introspect` | Token introspection |
 | POST | `/register` | Dynamic client registration |
-| GET | `/.well-known/oauth-authorization-server` | OAuth server metadata |
+| GET | `/.well-known/oauth-authorization-server` | RFC 8414 authorization-server metadata |
+| GET | `/.well-known/oauth-authorization-server/*` | RFC 8414 path-insertion variant (same metadata) |
+| GET | `/.well-known/oauth-protected-resource` | RFC 9728 protected-resource metadata |
+| GET | `/.well-known/oauth-protected-resource/*` | RFC 9728 path-insertion variant |
 
 The base path is derived from `serverUrl`. For example, if `serverUrl` is `https://example.com/api`, endpoints are at `/api/authorize`, `/api/token`, etc.
+
+### Discovery Metadata
+
+The authorization-server document advertises, among others,
+`authorization_endpoint`, `token_endpoint`, `registration_endpoint`,
+`revocation_endpoint` + `revocation_endpoint_auth_methods_supported`, and
+`introspection_endpoint` + `introspection_endpoint_auth_methods_supported`.
+
+The **path-insertion** routes serve clients that append the issuer/resource
+path to the well-known URL (RFC 8414 §3 / RFC 9728): a request to
+`/.well-known/oauth-protected-resource/mcp` returns the protected-resource
+document, with `resource` rebuilt as `serverUrl + '/<path>'` when the inserted
+path matches the configured resource path (`resourceUrl`'s path, default
+`/mcp`).
+
+### Audience Binding (RFC 8707)
+
+When the client passes a `resource` parameter during authorization, issued
+access tokens carry that resource as their `aud` claim
+(`aud = resource ?? audience ?? 'mcp-client'`). Note that `validateToken`
+deliberately does **not** enforce `aud` (non-breaking for existing
+deployments) — resource servers that need strict audience checks should
+verify the claim themselves (e.g. in a custom `BearerTokenVerifier`).
 
 ## OAuth Flow
 
@@ -102,27 +154,123 @@ After validation, `ctx.user` contains:
 }
 ```
 
-## Custom OAuth Store
+## Scope-Filtered Lists (`filterListsByScopes`)
 
-By default, tokens and clients are stored in memory. For production, implement the `IOAuthStore` interface:
+By default, `tools/list`, `resources/list`, `resources/templates/list`, and
+`prompts/list` return every registered item regardless of the caller's token.
+Set `filterListsByScopes: true` on `McpModule.forRoot` to hide items whose
+`@Scopes(...)` requirements are not covered by the caller's verified token
+scopes (from the streamable HTTP OAuth gate's `authInfo`):
 
 ```typescript
-import type { IOAuthStore } from '@nest-mcp/server';
+McpModule.forRoot({
+  name: 'my-server',
+  version: '1.0.0',
+  transport: McpTransportType.STREAMABLE_HTTP,
+  filterListsByScopes: true,
+  transportOptions: { streamableHttp: { oauth: { enabled: true } } },
+});
+```
 
+Items without required scopes are always listed. Execution-time authorization
+still applies independently of list filtering.
+
+## Custom Bearer-Token Verification
+
+The streamable HTTP transport's [OAuth gate](./transports.md#oauth-bearer-gate)
+verifies tokens through the `MCP_BEARER_TOKEN_VERIFIER` provider.
+`McpAuthModule` registers a JWT implementation (`JwtBearerTokenVerifier`) by
+default; override it for opaque tokens, remote introspection, or external
+issuers:
+
+```typescript
+import {
+  MCP_BEARER_TOKEN_VERIFIER,
+  type BearerTokenVerifier,
+} from '@nest-mcp/server';
+import type { McpAuthInfo } from '@nest-mcp/common';
+
+class IntrospectingVerifier implements BearerTokenVerifier {
+  async verify(token: string): Promise<McpAuthInfo | null> {
+    const res = await fetch('https://idp.example.com/introspect', {
+      method: 'POST',
+      body: new URLSearchParams({ token }),
+    });
+    const data = await res.json();
+    if (!data.active) return null;
+    return {
+      token,
+      clientId: data.client_id,
+      scopes: (data.scope ?? '').split(' ').filter(Boolean),
+      expiresAt: data.exp,
+      extra: { sub: data.sub },
+    };
+  }
+}
+
+// In your AppModule:
+providers: [{ provide: MCP_BEARER_TOKEN_VERIFIER, useClass: IntrospectingVerifier }],
+```
+
+## Custom OAuth Store
+
+By default, tokens and clients are stored in memory. For production, implement the `IOAuthStore` interface. A Postgres-backed sketch:
+
+```typescript
+import type { IOAuthStore, IssuedTokenRecord } from '@nest-mcp/server';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
 class PostgresOAuthStore implements IOAuthStore {
-  async storeClient(client) { /* ... */ }
-  async getClient(clientId) { /* ... */ }
-  async storeAuthCode(code) { /* ... */ }
-  async getAuthCode(code) { /* ... */ }
-  async removeAuthCode(code) { /* ... */ }
-  async revokeToken(jti) { /* ... */ }
-  async isTokenRevoked(jti) { /* ... */ }
+  constructor(private readonly db: DatabaseService) {}
+
+  async storeClient(client) {
+    await this.db.query(
+      `INSERT INTO oauth_clients (client_id, data) VALUES ($1, $2)
+       ON CONFLICT (client_id) DO UPDATE SET data = $2`,
+      [client.client_id, client],
+    );
+    return client;
+  }
+  async getClient(clientId) {
+    const row = await this.db.queryOne(
+      'SELECT data FROM oauth_clients WHERE client_id = $1', [clientId]);
+    return row?.data;
+  }
+  async storeAuthCode(code) { /* INSERT INTO oauth_codes ... */ }
+  async getAuthCode(code) { /* SELECT ... WHERE expires_at > now() */ }
+  async removeAuthCode(code) { /* DELETE FROM oauth_codes ... */ }
+  async revokeToken(jti) { /* INSERT INTO revoked_tokens (jti) ... */ }
+  async isTokenRevoked(jti) { /* SELECT EXISTS(...) */ }
+
+  // Optional issuance hook — see below.
+  async recordIssuedToken(rec: IssuedTokenRecord) {
+    await this.db.query(
+      `INSERT INTO issued_tokens (jti, type, client_id, user_id, scope, expires_at)
+       VALUES ($1, $2, $3, $4, $5, to_timestamp($6 / 1000.0))`,
+      [rec.jti, rec.type, rec.clientId, rec.userId, rec.scope, rec.expiresAt],
+    );
+  }
 }
 
 McpAuthModule.forRoot({
   jwtSecret: '...',
-  store: new PostgresOAuthStore(),
+  store: new PostgresOAuthStore(db),
   // ...
+});
+```
+
+With `forRootAsync`, return the store from the factory — a store provided
+there wins over the in-memory default:
+
+```typescript
+McpAuthModule.forRootAsync({
+  imports: [DatabaseModule],
+  inject: [DatabaseService],
+  useFactory: (db: DatabaseService) => ({
+    jwtSecret: process.env.JWT_SECRET!,
+    store: new PostgresOAuthStore(db),
+  }),
 });
 ```
 
@@ -137,6 +285,30 @@ McpAuthModule.forRoot({
 | `removeAuthCode(code)` | Delete an authorization code (after exchange) |
 | `revokeToken(jti)` | Mark a token as revoked by its JTI |
 | `isTokenRevoked(jti)` | Check if a token JTI has been revoked |
+| `recordIssuedToken(rec)?` | *Optional.* Called whenever a token is minted |
+
+### Token-Issuance Hook (`recordIssuedToken`)
+
+When the store implements the optional `recordIssuedToken`, it is invoked for
+**both** the access and the refresh token on every mint — the initial
+authorization-code grant and each refresh grant. This lets host apps track
+issued tokens and revoke whole refresh chains. Each call receives an
+`IssuedTokenRecord`:
+
+```typescript
+{
+  jti: string;                  // JWT ID of the minted token
+  type: 'access' | 'refresh';
+  clientId: string;
+  userId?: string;
+  scope?: string;
+  expiresAt: number;            // unix epoch milliseconds
+}
+```
+
+On the refresh path, the presented refresh token's `jti` is checked against
+`isTokenRevoked` before it is honored, and is revoked once rotated — a stolen
+older refresh token cannot be replayed.
 
 ## OAuthProviderAdapter
 

--- a/docs/server/transports.md
+++ b/docs/server/transports.md
@@ -29,6 +29,117 @@ McpModule.forRoot({
 |--------|------|---------|-------------|
 | `endpoint` | `string` | `'/mcp'` | HTTP path for the MCP endpoint |
 | `stateless` | `boolean` | `false` | Stateless mode (no session tracking) |
+| `sessionIdGenerator` | `() => string` | `randomUUID` | Custom session-ID generator (ignored when `stateless`) |
+| `enableJsonResponse` | `boolean` | `false` | Respond with plain JSON instead of SSE streams |
+| `eventStore` | `McpEventStore` | — | Event store enabling resumability (reconnect + replay via `Last-Event-ID`) |
+| `onsessioninitialized` | `(sessionId) => void \| Promise<void>` | — | Callback when a new session is initialized |
+| `onsessionclosed` | `(sessionId) => void \| Promise<void>` | — | Callback when a session is closed |
+| `retryInterval` | `number` | — | `retry:` interval (ms) advertised on SSE streams |
+| `allowedHosts` | `string[]` | — | Hostnames accepted by DNS-rebinding protection |
+| `allowedOrigins` | `string[]` | — | Origins accepted by DNS-rebinding protection |
+| `enableDnsRebindingProtection` | `boolean` | `false` | Enable the SDK transport's DNS-rebinding protection |
+| `oauth` | `object` | — | Bearer-token gate for the endpoint (see below) |
+| `controllerGuards` | `unknown[]` | — | NestJS guards applied to the generated controller |
+| `controllerDecorators` | `ClassDecorator[]` | — | Class decorators applied to the generated controller |
+
+### OAuth Bearer Gate
+
+Setting `oauth.enabled: true` protects the streamable HTTP endpoint with a
+bearer-token check performed before any JSON-RPC processing. The gate is
+**inactive unless `enabled` is true**, so existing deployments are unaffected.
+
+```typescript
+transportOptions: {
+  streamableHttp: {
+    oauth: {
+      enabled: true,
+      required: true,                 // default true
+      // resourceMetadataUrl: 'https://api.example.com/.well-known/oauth-protected-resource/mcp',
+      bindSessionToUser: true,        // default true
+    },
+  },
+},
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `boolean` | — | Activates the gate |
+| `required` | `boolean` | `true` | When `false`, requests without a valid token pass through anonymously |
+| `resourceMetadataUrl` | `string` | path-insertion URL | RFC 9728 metadata URL advertised in `WWW-Authenticate` |
+| `bindSessionToUser` | `boolean` | `true` | Bind each session to the principal that initialized it |
+
+Tokens are verified by the `MCP_BEARER_TOKEN_VERIFIER` provider. Importing
+`McpAuthModule.forRoot(...)` supplies the default JWT implementation; host
+apps can re-provide the token for opaque-token introspection (see
+[auth.md](./auth.md#custom-bearer-token-verification)).
+
+**401 discovery flow.** When a request has no valid token (and `required` is
+not `false`), the server responds `401` with a `WWW-Authenticate` challenge:
+
+```
+WWW-Authenticate: Bearer realm="mcp", resource_metadata="https://host/.well-known/oauth-protected-resource/mcp"
+```
+
+MCP clients follow `resource_metadata` to the RFC 9728 protected-resource
+document, discover the authorization server from `authorization_servers`,
+fetch its RFC 8414 metadata, run the OAuth flow, and retry with a Bearer
+token. The default `resource_metadata` URL uses the path-insertion form built
+from the request's `Host` header and the configured endpoint; set
+`resourceMetadataUrl` to override it.
+
+**Session binding.** With `bindSessionToUser` (default when oauth is
+enabled), the principal (`clientId` + `sub`) that initializes a stateful
+session is recorded, and every subsequent request for that `mcp-session-id`
+must present a token for the same principal — otherwise the server responds
+`403`. Binding only applies when `oauth.enabled` is true, so existing
+stateful servers never start rejecting requests; set
+`bindSessionToUser: false` to opt out. The verified identity is surfaced to
+handlers and guards as `ctx.authInfo`.
+
+### DNS-Rebinding Protection
+
+`allowedHosts`, `allowedOrigins`, and `enableDnsRebindingProtection` are
+forwarded to the SDK's `StreamableHTTPServerTransport`, which validates the
+`Host`/`Origin` headers of every request when protection is enabled:
+
+```typescript
+transportOptions: {
+  streamableHttp: {
+    enableDnsRebindingProtection: true,
+    allowedHosts: ['api.example.com'],
+    allowedOrigins: ['https://app.example.com'],
+  },
+},
+```
+
+### Controller Guards and Decorators
+
+`controllerGuards` and `controllerDecorators` are applied to the generated
+NestJS controller — useful to plug in existing HTTP guards (e.g. an
+organization-wide `AuthGuard`) or decorators like Swagger's `@ApiTags`:
+
+```typescript
+transportOptions: {
+  streamableHttp: {
+    controllerGuards: [MyHttpAuthGuard],
+    controllerDecorators: [ApiTags('mcp')],
+  },
+},
+```
+
+> **`forRootAsync` note:** the controller class is created when the module is
+> *defined*, before the async factory runs. Controller-shape configuration —
+> `endpoint`, `controllerGuards`, `controllerDecorators` — must therefore be
+> provided statically on the `forRootAsync` options object
+> (`transportOptions`), while all runtime options resolved by `useFactory`
+> flow through `MCP_OPTIONS`.
+
+### Resumability
+
+Provide an `eventStore` to let clients resume an interrupted SSE stream: the
+SDK assigns event IDs, and on reconnect (with `Last-Event-ID`) replays missed
+messages through `replayEventsAfter`. Any object matching the `McpEventStore`
+interface (structural mirror of the SDK `EventStore`) works.
 
 ### Endpoints
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -51,14 +51,14 @@
     "@nest-mcp/common": "workspace:*"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "reflect-metadata": ">=0.1.13",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/testing": "^11.0.0",

--- a/packages/common/src/interfaces/mcp-auth.interface.ts
+++ b/packages/common/src/interfaces/mcp-auth.interface.ts
@@ -1,5 +1,25 @@
 export type McpGuardClass = abstract new (...args: unknown[]) => McpGuard;
 
+/**
+ * Verified bearer-token identity attached to a request. Structural mirror of
+ * the MCP SDK `AuthInfo` (`@nest-mcp/common` stays SDK-free); the SDK's
+ * concrete type is assignable to this one.
+ */
+export interface McpAuthInfo {
+  /** The raw access token as presented by the client. */
+  token: string;
+  /** OAuth client the token was issued to. */
+  clientId: string;
+  /** Scopes granted to the token. */
+  scopes: string[];
+  /** Expiry as a unix timestamp in seconds, when known. */
+  expiresAt?: number;
+  /** RFC 8707 resource the token is bound to, when known. */
+  resource?: string;
+  /** Extra verifier-specific claims (e.g. `sub`). */
+  extra?: Record<string, unknown>;
+}
+
 export interface McpAuthConfig {
   guards?: McpGuardClass[];
   allowUnauthenticatedAccess?: boolean;
@@ -36,6 +56,8 @@ export interface McpGuardContext {
     [key: string]: unknown;
   };
   request?: unknown;
+  /** Verified bearer-token identity, when HTTP edge auth is enabled. */
+  authInfo?: McpAuthInfo;
   metadata: Record<string, unknown>;
 }
 

--- a/packages/common/src/interfaces/mcp-context.interface.ts
+++ b/packages/common/src/interfaces/mcp-context.interface.ts
@@ -1,3 +1,4 @@
+import type { McpAuthInfo } from './mcp-auth.interface';
 import type { ElicitRequest, ElicitResult } from './mcp-elicitation.interface';
 import type { McpSamplingParams, McpSamplingResult } from './mcp-sampling.interface';
 import type { ToolContent } from './mcp-tool.interface';
@@ -16,6 +17,8 @@ export interface McpExecutionContext {
   log: McpContextLogger;
   request?: unknown;
   user?: McpAuthenticatedUser;
+  /** Verified bearer-token identity, when HTTP edge auth is enabled. */
+  authInfo?: McpAuthInfo;
   metadata: Record<string, unknown>;
   signal?: AbortSignal;
   /** Emit incremental content chunks during tool execution (FastMCP streaming extension). */

--- a/packages/common/src/interfaces/mcp-options.interface.ts
+++ b/packages/common/src/interfaces/mcp-options.interface.ts
@@ -46,6 +46,12 @@ export interface McpModuleOptions {
   // Auth
   guards?: McpGuardClass[];
   allowUnauthenticatedAccess?: boolean;
+  /**
+   * When true, `tools/list`, `resources/list`, and `prompts/list` only return
+   * items whose required scopes are covered by the caller's token scopes.
+   * Default false (lists are not filtered).
+   */
+  filterListsByScopes?: boolean;
 
   // Resilience (global defaults)
   resilience?: {

--- a/packages/common/src/interfaces/mcp-transport.interface.ts
+++ b/packages/common/src/interfaces/mcp-transport.interface.ts
@@ -38,6 +38,29 @@ export interface StreamableHttpTransportOptions {
   onsessionclosed?: (sessionId: string) => void | Promise<void>;
   /** Retry interval in milliseconds for SSE streams. */
   retryInterval?: number;
+  /** Hostnames allowed by the SDK transport's DNS-rebinding protection. */
+  allowedHosts?: string[];
+  /** Origins allowed by the SDK transport's DNS-rebinding protection. */
+  allowedOrigins?: string[];
+  /** Enable the SDK transport's DNS-rebinding protection (requires `allowedHosts` and/or `allowedOrigins`). */
+  enableDnsRebindingProtection?: boolean;
+  /**
+   * Bearer-token gate for the streamable HTTP endpoint. Inactive unless
+   * `enabled` is true, so existing deployments are unaffected.
+   */
+  oauth?: {
+    enabled: boolean;
+    /** When false, requests without a token pass through anonymously. Default true. */
+    required?: boolean;
+    /** RFC 9728 protected-resource metadata URL advertised in `WWW-Authenticate`. Defaults to path-insertion on the request host. */
+    resourceMetadataUrl?: string;
+    /** Bind each session to the principal that initialized it. Default true. */
+    bindSessionToUser?: boolean;
+  };
+  /** NestJS guards applied to the generated streamable HTTP controller. */
+  controllerGuards?: unknown[];
+  /** Class decorators applied to the generated streamable HTTP controller. */
+  controllerDecorators?: ClassDecorator[];
 }
 
 export interface SseTransportOptions {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -54,14 +54,14 @@
     "@nest-mcp/client": "workspace:*"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "reflect-metadata": ">=0.1.13",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/testing": "^11.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -58,7 +58,7 @@
     "path-to-regexp": "^8.0.0"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@nestjs/common": "^10.0.0 || ^11.0.0",
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "reflect-metadata": ">=0.1.13",
@@ -66,7 +66,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",

--- a/packages/server/src/auth/auth.module.spec.ts
+++ b/packages/server/src/auth/auth.module.spec.ts
@@ -5,6 +5,10 @@ import type {
   OAuthProviderAdapter,
   OAuthProviderUser,
 } from './interfaces/oauth-provider.interface';
+import {
+  JwtBearerTokenVerifier,
+  MCP_BEARER_TOKEN_VERIFIER,
+} from './services/bearer-verifier.service';
 import { MCP_OAUTH_STORE, OAuthClientService } from './services/client.service';
 import { JwtTokenService, MCP_AUTH_OPTIONS } from './services/jwt-token.service';
 import { MemoryOAuthStore } from './stores/memory-store.service';
@@ -79,6 +83,25 @@ describe('McpAuthModule', () => {
         validateUser: async () => null,
       });
       expect(result.exports).toContain(MCP_AUTH_OPTIONS);
+    });
+
+    it('provides JwtBearerTokenVerifier under MCP_BEARER_TOKEN_VERIFIER (overridable)', () => {
+      const result = McpAuthModule.forRoot({
+        jwtSecret: TEST_SECRET,
+        validateUser: async () => null,
+      });
+      const verifierProvider = (result.providers as { provide: unknown; useClass: unknown }[]).find(
+        (p) => p.provide === MCP_BEARER_TOKEN_VERIFIER,
+      );
+      expect(verifierProvider?.useClass).toBe(JwtBearerTokenVerifier);
+    });
+
+    it('exports MCP_BEARER_TOKEN_VERIFIER', () => {
+      const result = McpAuthModule.forRoot({
+        jwtSecret: TEST_SECRET,
+        validateUser: async () => null,
+      });
+      expect(result.exports).toContain(MCP_BEARER_TOKEN_VERIFIER);
     });
 
     it('exports MCP_OAUTH_STORE', () => {

--- a/packages/server/src/auth/auth.module.spec.ts
+++ b/packages/server/src/auth/auth.module.spec.ts
@@ -15,6 +15,19 @@ import { MemoryOAuthStore } from './stores/memory-store.service';
 
 const TEST_SECRET = 'a'.repeat(32);
 
+type FactoryProvider = {
+  provide: unknown;
+  // biome-ignore lint/suspicious/noExplicitAny: test helper mirrors Nest's loose factory typing
+  useFactory: (...args: any[]) => any;
+  inject?: unknown[];
+};
+
+function findFactoryProvider(providers: unknown, token: unknown): FactoryProvider | undefined {
+  return (providers as FactoryProvider[]).find(
+    (p) => typeof p === 'object' && p !== null && p.provide === token,
+  );
+}
+
 class FakeProvider implements OAuthProviderAdapter {
   readonly name = 'FakeProvider';
 
@@ -112,28 +125,102 @@ describe('McpAuthModule', () => {
       expect(result.exports).toContain(MCP_OAUTH_STORE);
     });
 
-    it('uses MemoryOAuthStore by default', () => {
+    it('provides MCP_OAUTH_STORE via a factory injecting MCP_AUTH_OPTIONS', () => {
       const result = McpAuthModule.forRoot({
         jwtSecret: TEST_SECRET,
         validateUser: async () => null,
       });
-      const storeProvider = (result.providers as { provide: unknown; useValue: unknown }[]).find(
-        (p) => p.provide === MCP_OAUTH_STORE,
-      );
-      expect(storeProvider?.useValue).toBeInstanceOf(MemoryOAuthStore);
+      const storeProvider = findFactoryProvider(result.providers, MCP_OAUTH_STORE);
+      expect(storeProvider?.inject).toEqual([MCP_AUTH_OPTIONS]);
     });
 
-    it('uses provided custom store instead of MemoryOAuthStore', () => {
-      const customStore = { get: () => undefined, set: () => {}, delete: () => {} } as never;
+    it('store factory creates MemoryOAuthStore by default', () => {
+      const result = McpAuthModule.forRoot({
+        jwtSecret: TEST_SECRET,
+        validateUser: async () => null,
+      });
+      const storeProvider = findFactoryProvider(result.providers, MCP_OAUTH_STORE);
+      expect(storeProvider?.useFactory({ jwtSecret: TEST_SECRET })).toBeInstanceOf(
+        MemoryOAuthStore,
+      );
+    });
+
+    it('store factory returns the store from options when provided', () => {
+      const customStore = { isTokenRevoked: async () => false } as never;
       const result = McpAuthModule.forRoot({
         jwtSecret: TEST_SECRET,
         store: customStore,
         validateUser: async () => null,
       });
-      const storeProvider = (result.providers as { provide: unknown; useValue: unknown }[]).find(
-        (p) => p.provide === MCP_OAUTH_STORE,
+      const storeProvider = findFactoryProvider(result.providers, MCP_OAUTH_STORE);
+      expect(storeProvider?.useFactory({ jwtSecret: TEST_SECRET, store: customStore })).toBe(
+        customStore,
       );
-      expect(storeProvider?.useValue).toBe(customStore);
+    });
+  });
+
+  describe('forRootAsync', () => {
+    it('returns McpAuthModule with controllers and pass-through imports', () => {
+      class FakeConfigModule {}
+      const result = McpAuthModule.forRootAsync({
+        imports: [FakeConfigModule],
+        serverUrl: 'https://auth.example.com',
+        useFactory: () => ({ jwtSecret: TEST_SECRET }),
+      });
+
+      expect(result.module).toBe(McpAuthModule);
+      expect(result.imports).toEqual([FakeConfigModule]);
+      expect(result.controllers).toHaveLength(2);
+    });
+
+    it('provides MCP_AUTH_OPTIONS via the given factory and inject tokens', async () => {
+      const useFactory = vi.fn().mockResolvedValue({ jwtSecret: TEST_SECRET });
+      const result = McpAuthModule.forRootAsync({ useFactory, inject: ['CONFIG'] });
+
+      const optionsProvider = findFactoryProvider(result.providers, MCP_AUTH_OPTIONS);
+      expect(optionsProvider?.inject).toEqual(['CONFIG']);
+
+      const resolved = await optionsProvider?.useFactory({ some: 'dep' });
+      expect(useFactory).toHaveBeenCalledWith({ some: 'dep' });
+      expect(resolved).toEqual({ jwtSecret: TEST_SECRET });
+    });
+
+    it('validates jwtSecret length when the factory resolves', async () => {
+      const result = McpAuthModule.forRootAsync({
+        useFactory: () => ({ jwtSecret: 'short' }),
+      });
+
+      const optionsProvider = findFactoryProvider(result.providers, MCP_AUTH_OPTIONS);
+      await expect(optionsProvider?.useFactory()).rejects.toThrow(
+        'jwtSecret must be at least 32 characters',
+      );
+    });
+
+    it('store factory lets a factory-provided store win over the default', () => {
+      const customStore = { isTokenRevoked: async () => false } as never;
+      const result = McpAuthModule.forRootAsync({
+        useFactory: () => ({ jwtSecret: TEST_SECRET, store: customStore }),
+      });
+
+      const storeProvider = findFactoryProvider(result.providers, MCP_OAUTH_STORE);
+      expect(storeProvider?.inject).toEqual([MCP_AUTH_OPTIONS]);
+      expect(storeProvider?.useFactory({ jwtSecret: TEST_SECRET, store: customStore })).toBe(
+        customStore,
+      );
+      expect(storeProvider?.useFactory({ jwtSecret: TEST_SECRET })).toBeInstanceOf(
+        MemoryOAuthStore,
+      );
+    });
+
+    it('exports the same tokens as forRoot', () => {
+      const result = McpAuthModule.forRootAsync({
+        useFactory: () => ({ jwtSecret: TEST_SECRET }),
+      });
+
+      expect(result.exports).toContain(JwtTokenService);
+      expect(result.exports).toContain(MCP_AUTH_OPTIONS);
+      expect(result.exports).toContain(MCP_OAUTH_STORE);
+      expect(result.exports).toContain(MCP_BEARER_TOKEN_VERIFIER);
     });
   });
 

--- a/packages/server/src/auth/auth.module.ts
+++ b/packages/server/src/auth/auth.module.ts
@@ -7,6 +7,10 @@ import type { OAuthProviderAdapter } from './interfaces/oauth-provider.interface
 import { createOAuthController } from './oauth/oauth.controller';
 import { createWellKnownController } from './oauth/well-known.controller';
 import { AuthAuditService } from './services/auth-audit.service';
+import {
+  JwtBearerTokenVerifier,
+  MCP_BEARER_TOKEN_VERIFIER,
+} from './services/bearer-verifier.service';
 import { MCP_OAUTH_STORE, OAuthClientService } from './services/client.service';
 import { JwtTokenService, MCP_AUTH_OPTIONS } from './services/jwt-token.service';
 import { OAuthFlowService } from './services/oauth-flow.service';
@@ -31,6 +35,7 @@ export class McpAuthModule {
       providers: [
         { provide: MCP_AUTH_OPTIONS, useValue: options },
         { provide: MCP_OAUTH_STORE, useValue: store },
+        { provide: MCP_BEARER_TOKEN_VERIFIER, useClass: JwtBearerTokenVerifier },
         JwtTokenService,
         OAuthClientService,
         OAuthFlowService,
@@ -45,6 +50,7 @@ export class McpAuthModule {
         JwtAuthGuard,
         MCP_AUTH_OPTIONS,
         MCP_OAUTH_STORE,
+        MCP_BEARER_TOKEN_VERIFIER,
       ],
     };
   }

--- a/packages/server/src/auth/auth.module.ts
+++ b/packages/server/src/auth/auth.module.ts
@@ -1,8 +1,11 @@
 import { McpError } from '@nest-mcp/common';
-import { type DynamicModule, Module } from '@nestjs/common';
+import { type DynamicModule, Module, type Provider } from '@nestjs/common';
 import { AuthRateLimitGuard } from './guards/auth-rate-limit.guard';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
-import type { McpAuthModuleOptions } from './interfaces/auth-module-options.interface';
+import type {
+  McpAuthModuleAsyncOptions,
+  McpAuthModuleOptions,
+} from './interfaces/auth-module-options.interface';
 import type { OAuthProviderAdapter } from './interfaces/oauth-provider.interface';
 import { createOAuthController } from './oauth/oauth.controller';
 import { createWellKnownController } from './oauth/well-known.controller';
@@ -16,42 +19,86 @@ import { JwtTokenService, MCP_AUTH_OPTIONS } from './services/jwt-token.service'
 import { OAuthFlowService } from './services/oauth-flow.service';
 import { MemoryOAuthStore } from './stores/memory-store.service';
 
+function validateAuthOptions(options: McpAuthModuleOptions): McpAuthModuleOptions {
+  if (!options.jwtSecret || options.jwtSecret.length < 32) {
+    throw new McpError('McpAuthModule: jwtSecret must be at least 32 characters');
+  }
+  return options;
+}
+
+/**
+ * `MCP_OAUTH_STORE` factory: an explicitly configured `options.store` wins;
+ * otherwise an in-memory store is created.
+ */
+const storeProvider: Provider = {
+  provide: MCP_OAUTH_STORE,
+  useFactory: (options: McpAuthModuleOptions) => options.store ?? new MemoryOAuthStore(),
+  inject: [MCP_AUTH_OPTIONS],
+};
+
+const sharedProviders: Provider[] = [
+  storeProvider,
+  { provide: MCP_BEARER_TOKEN_VERIFIER, useClass: JwtBearerTokenVerifier },
+  JwtTokenService,
+  OAuthClientService,
+  OAuthFlowService,
+  JwtAuthGuard,
+  AuthRateLimitGuard,
+  AuthAuditService,
+];
+
+const moduleExports = [
+  JwtTokenService,
+  OAuthClientService,
+  JwtAuthGuard,
+  MCP_AUTH_OPTIONS,
+  MCP_OAUTH_STORE,
+  MCP_BEARER_TOKEN_VERIFIER,
+];
+
 @Module({})
 // biome-ignore lint/complexity/noStaticOnlyClass: NestJS requires module classes
 export class McpAuthModule {
   static forRoot(options: McpAuthModuleOptions): DynamicModule {
-    if (!options.jwtSecret || options.jwtSecret.length < 32) {
-      throw new McpError('McpAuthModule: jwtSecret must be at least 32 characters');
-    }
+    validateAuthOptions(options);
 
     const oauthBasePath = options.serverUrl ? new URL(options.serverUrl).pathname : '';
     const OAuthCtrl = createOAuthController(oauthBasePath);
-    const WellKnownCtrl = createWellKnownController(options);
-
-    const store = options.store ?? new MemoryOAuthStore();
+    const WellKnownCtrl = createWellKnownController();
 
     return {
       module: McpAuthModule,
+      providers: [{ provide: MCP_AUTH_OPTIONS, useValue: options }, ...sharedProviders],
+      controllers: [OAuthCtrl, WellKnownCtrl],
+      exports: moduleExports,
+    };
+  }
+
+  /**
+   * Async variant: options are produced by a DI-aware factory. Controllers
+   * are created from the STATIC `serverUrl` on the async options (controller
+   * shape cannot depend on the factory result); everything else flows through
+   * the resolved `MCP_AUTH_OPTIONS`.
+   */
+  static forRootAsync(options: McpAuthModuleAsyncOptions): DynamicModule {
+    const oauthBasePath = options.serverUrl ? new URL(options.serverUrl).pathname : '';
+    const OAuthCtrl = createOAuthController(oauthBasePath);
+    const WellKnownCtrl = createWellKnownController();
+
+    return {
+      module: McpAuthModule,
+      imports: options.imports ?? [],
       providers: [
-        { provide: MCP_AUTH_OPTIONS, useValue: options },
-        { provide: MCP_OAUTH_STORE, useValue: store },
-        { provide: MCP_BEARER_TOKEN_VERIFIER, useClass: JwtBearerTokenVerifier },
-        JwtTokenService,
-        OAuthClientService,
-        OAuthFlowService,
-        JwtAuthGuard,
-        AuthRateLimitGuard,
-        AuthAuditService,
+        {
+          provide: MCP_AUTH_OPTIONS,
+          useFactory: async (...args: unknown[]) =>
+            validateAuthOptions(await options.useFactory(...args)),
+          inject: options.inject ?? [],
+        },
+        ...sharedProviders,
       ],
       controllers: [OAuthCtrl, WellKnownCtrl],
-      exports: [
-        JwtTokenService,
-        OAuthClientService,
-        JwtAuthGuard,
-        MCP_AUTH_OPTIONS,
-        MCP_OAUTH_STORE,
-        MCP_BEARER_TOKEN_VERIFIER,
-      ],
+      exports: moduleExports,
     };
   }
 

--- a/packages/server/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/packages/server/src/auth/guards/jwt-auth.guard.spec.ts
@@ -23,6 +23,48 @@ describe('JwtAuthGuard', () => {
     };
   }
 
+  // --- authInfo fast path ---
+
+  it('returns true and populates user from authInfo without re-parsing headers', async () => {
+    const context = makeContext(undefined);
+    context.authInfo = {
+      token: 'edge-verified',
+      clientId: 'client-1',
+      scopes: ['read', 'write'],
+      extra: { sub: 'user-42' },
+    };
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(context.user).toEqual({ id: 'user-42', scopes: ['read', 'write'] });
+    expect(jwtService.validateToken).not.toHaveBeenCalled();
+  });
+
+  it('falls back to clientId when authInfo has no sub claim', async () => {
+    const context = makeContext(undefined);
+    context.authInfo = { token: 't', clientId: 'client-7', scopes: [] };
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(context.user).toEqual({ id: 'client-7', scopes: [] });
+  });
+
+  // --- requestInfo-shaped request ---
+
+  it('parses bearer token from a requestInfo-shaped request', async () => {
+    jwtService.validateToken.mockReturnValue({ sub: 'user-9', scope: 'read' });
+    // ctx.request is the SDK's per-request requestInfo: { headers: Record<...> }
+    const context = makeContext({ headers: { authorization: 'Bearer per-request-token' } });
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(jwtService.validateToken).toHaveBeenCalledWith('per-request-token');
+    expect(context.user).toEqual(expect.objectContaining({ id: 'user-9', scopes: ['read'] }));
+  });
+
   // --- Missing / Invalid auth header ---
 
   it('returns false when no authorization header', async () => {

--- a/packages/server/src/auth/guards/jwt-auth.guard.ts
+++ b/packages/server/src/auth/guards/jwt-auth.guard.ts
@@ -7,6 +7,16 @@ export class JwtAuthGuard implements McpGuard {
   constructor(private readonly jwtService: JwtTokenService) {}
 
   async canActivate(context: McpGuardContext): Promise<boolean> {
+    // Fast path: the HTTP edge already verified the bearer token and the SDK
+    // surfaced it per-request as authInfo — trust it instead of re-parsing.
+    if (context.authInfo) {
+      context.user = {
+        id: (context.authInfo.extra?.sub as string) ?? context.authInfo.clientId,
+        scopes: context.authInfo.scopes,
+      };
+      return true;
+    }
+
     const request = context.request as { headers?: { authorization?: string } } | undefined;
     if (!request?.headers?.authorization) return false;
 

--- a/packages/server/src/auth/guards/tool-auth.guard.spec.ts
+++ b/packages/server/src/auth/guards/tool-auth.guard.spec.ts
@@ -6,9 +6,18 @@ import { ToolAuthGuardService } from './tool-auth.guard';
 
 describe('ToolAuthGuardService', () => {
   let guard: ToolAuthGuardService;
+  let moduleRef: { get: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
-    guard = new ToolAuthGuardService();
+    // Default: guards are not registered in DI — fall back to bare `new`.
+    moduleRef = {
+      get: vi.fn().mockImplementation(() => {
+        throw new Error('not found');
+      }),
+    };
+    guard = new ToolAuthGuardService(
+      moduleRef as unknown as ConstructorParameters<typeof ToolAuthGuardService>[0],
+    );
   });
 
   function makeContext(overrides: Partial<McpGuardContext> = {}): McpGuardContext {
@@ -190,6 +199,35 @@ describe('ToolAuthGuardService', () => {
       await guard.checkAuthorization(tool, context);
 
       expect(canActivate).toHaveBeenCalledWith(context);
+    });
+
+    it('resolves guards through DI when registered as providers', async () => {
+      const canActivate = vi.fn().mockResolvedValue(true);
+      class DiGuard {}
+      moduleRef.get.mockReturnValue({ canActivate });
+
+      const tool = makeTool({
+        guards: [DiGuard as unknown as abstract new (...a: unknown[]) => unknown],
+      });
+      await guard.checkAuthorization(tool, makeContext());
+
+      expect(moduleRef.get).toHaveBeenCalledWith(DiGuard, { strict: false });
+      expect(canActivate).toHaveBeenCalled();
+    });
+
+    it('falls back to bare new when the guard is not in DI', async () => {
+      const canActivate = vi.fn().mockResolvedValue(true);
+      class PlainGuard {
+        canActivate = canActivate;
+      }
+
+      const tool = makeTool({
+        guards: [PlainGuard as unknown as abstract new (...a: unknown[]) => unknown],
+      });
+      await guard.checkAuthorization(tool, makeContext());
+
+      expect(moduleRef.get).toHaveBeenCalledWith(PlainGuard, { strict: false });
+      expect(canActivate).toHaveBeenCalled();
     });
   });
 });

--- a/packages/server/src/auth/guards/tool-auth.guard.ts
+++ b/packages/server/src/auth/guards/tool-auth.guard.ts
@@ -1,10 +1,14 @@
 import { AuthorizationError } from '@nest-mcp/common';
-import type { AuthorizableItem, McpGuard, McpGuardClass, McpGuardContext } from '@nest-mcp/common';
+import type { AuthorizableItem, McpGuardContext } from '@nest-mcp/common';
 import { Injectable, Logger } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { resolveGuard } from '../../utils/resolve-guard.util';
 
 @Injectable()
 export class ToolAuthGuardService {
   private readonly logger = new Logger(ToolAuthGuardService.name);
+
+  constructor(private readonly moduleRef: ModuleRef) {}
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sequential auth checks are inherently branchy
   async checkAuthorization(item: AuthorizableItem, context: McpGuardContext): Promise<void> {
@@ -36,7 +40,7 @@ export class ToolAuthGuardService {
     // Execute custom guards
     if (item.guards?.length) {
       for (const GuardClass of item.guards) {
-        const guard = new (GuardClass as unknown as new () => McpGuard)();
+        const guard = resolveGuard(this.moduleRef, GuardClass);
         if (typeof guard.canActivate === 'function') {
           const allowed = await guard.canActivate(context);
           if (!allowed) {

--- a/packages/server/src/auth/interfaces/auth-module-options.interface.ts
+++ b/packages/server/src/auth/interfaces/auth-module-options.interface.ts
@@ -1,5 +1,23 @@
 import type { IOAuthStore } from '../stores/oauth-store.interface';
 
+export interface McpAuthModuleAsyncOptions {
+  /** Modules whose exported providers the factory may inject. */
+  // biome-ignore lint/suspicious/noExplicitAny: NestJS DynamicModule requires broad module types
+  imports?: any[];
+  /**
+   * Static base URL used to derive the OAuth controllers' base path.
+   * Controllers are created at module-definition time — before `useFactory`
+   * runs — so this cannot come from the factory. All runtime options
+   * (including `serverUrl` for metadata/issuer purposes) flow through
+   * `MCP_AUTH_OPTIONS` as resolved by `useFactory`.
+   */
+  serverUrl?: string;
+  // biome-ignore lint/suspicious/noExplicitAny: NestJS factory pattern requires broad parameter types
+  useFactory: (...args: any[]) => McpAuthModuleOptions | Promise<McpAuthModuleOptions>;
+  // biome-ignore lint/suspicious/noExplicitAny: NestJS injection tokens have broad types
+  inject?: any[];
+}
+
 export interface McpAuthModuleOptions {
   jwtSecret: string;
   issuer?: string;

--- a/packages/server/src/auth/oauth/well-known.controller.spec.ts
+++ b/packages/server/src/auth/oauth/well-known.controller.spec.ts
@@ -1,28 +1,54 @@
 import 'reflect-metadata';
 import { describe, expect, it } from 'vitest';
-import { createWellKnownController } from './well-known.controller';
+import type { McpAuthModuleOptions } from '../interfaces/auth-module-options.interface';
+import {
+  buildWellKnownWildcardRoute,
+  createWellKnownController,
+  extractWellKnownRest,
+} from './well-known.controller';
 
-const baseOptions = {
+const baseOptions: McpAuthModuleOptions = {
   jwtSecret: 'secret',
   serverUrl: 'https://auth.example.com',
 };
 
+type WellKnownInstance = {
+  getAuthorizationServerMetadata(): Record<string, unknown>;
+  getAuthorizationServerMetadataForPath(): Record<string, unknown>;
+  getProtectedResourceMetadata(): Record<string, unknown>;
+  getProtectedResourceMetadataForPath(req: { url?: string; originalUrl?: string }): Record<
+    string,
+    unknown
+  >;
+};
+
+function makeInstance(options: McpAuthModuleOptions): WellKnownInstance {
+  const Ctrl = createWellKnownController();
+  return new (Ctrl as new (options: McpAuthModuleOptions) => WellKnownInstance)(options);
+}
+
 describe('createWellKnownController', () => {
   it('returns a class (function)', () => {
-    const ctrl = createWellKnownController(baseOptions);
+    const ctrl = createWellKnownController();
     expect(typeof ctrl).toBe('function');
   });
 
   it('applies @Controller(".well-known") to the returned class', () => {
-    const ctrl = createWellKnownController(baseOptions);
+    const ctrl = createWellKnownController();
     expect(Reflect.getMetadata('path', ctrl)).toBe('.well-known');
   });
 
+  it('constructor-injects MCP_AUTH_OPTIONS (options read at request time, not closed over)', () => {
+    // Same controller class serves whichever options DI provides.
+    const a = makeInstance(baseOptions);
+    const b = makeInstance({ jwtSecret: 'secret', serverUrl: 'https://other.example.com' });
+    expect(a.getAuthorizationServerMetadata().issuer).toBe('https://auth.example.com');
+    expect(b.getAuthorizationServerMetadata().issuer).toBe('https://other.example.com');
+  });
+
   describe('getAuthorizationServerMetadata()', () => {
-    function invokeAuthMeta(options: Parameters<typeof createWellKnownController>[0]) {
-      const Ctrl = createWellKnownController(options);
-      const instance = new (Ctrl as new () => { getAuthorizationServerMetadata(): unknown })();
-      return instance.getAuthorizationServerMetadata() as Record<string, unknown>;
+    function invokeAuthMeta(options: McpAuthModuleOptions) {
+      return makeInstance(options).getAuthorizationServerMetadata();
     }
 
     it('uses serverUrl as issuer by default', () => {
@@ -48,6 +74,27 @@ describe('createWellKnownController', () => {
     it('builds revocation_endpoint from serverUrl', () => {
       const meta = invokeAuthMeta(baseOptions);
       expect(meta.revocation_endpoint).toBe('https://auth.example.com/revoke');
+    });
+
+    it('builds introspection_endpoint from serverUrl', () => {
+      const meta = invokeAuthMeta(baseOptions);
+      expect(meta.introspection_endpoint).toBe('https://auth.example.com/introspect');
+    });
+
+    it('advertises introspection_endpoint_auth_methods_supported', () => {
+      const meta = invokeAuthMeta(baseOptions);
+      expect(meta.introspection_endpoint_auth_methods_supported).toEqual([
+        'client_secret_post',
+        'none',
+      ]);
+    });
+
+    it('advertises revocation_endpoint_auth_methods_supported', () => {
+      const meta = invokeAuthMeta(baseOptions);
+      expect(meta.revocation_endpoint_auth_methods_supported).toEqual([
+        'client_secret_post',
+        'none',
+      ]);
     });
 
     it('includes registration_endpoint when enableDynamicRegistration is not false', () => {
@@ -93,10 +140,8 @@ describe('createWellKnownController', () => {
   });
 
   describe('getProtectedResourceMetadata()', () => {
-    function invokeResourceMeta(options: Parameters<typeof createWellKnownController>[0]) {
-      const Ctrl = createWellKnownController(options);
-      const instance = new (Ctrl as new () => { getProtectedResourceMetadata(): unknown })();
-      return instance.getProtectedResourceMetadata() as Record<string, unknown>;
+    function invokeResourceMeta(options: McpAuthModuleOptions) {
+      return makeInstance(options).getProtectedResourceMetadata();
     }
 
     it('uses resourceUrl from options when provided', () => {
@@ -135,6 +180,129 @@ describe('createWellKnownController', () => {
     it('returns bearer_methods_supported as ["header"]', () => {
       const meta = invokeResourceMeta(baseOptions);
       expect(meta.bearer_methods_supported).toEqual(['header']);
+    });
+  });
+
+  describe('path-insertion wildcard routes (RFC 8414 / RFC 9728)', () => {
+    it('registers a GET wildcard route for oauth-authorization-server', () => {
+      const Ctrl = createWellKnownController();
+      const proto = Ctrl.prototype as Record<string, unknown>;
+      const path = Reflect.getMetadata(
+        'path',
+        proto.getAuthorizationServerMetadataForPath as object,
+      );
+      // Nest 11 is installed in this workspace → named-wildcard syntax.
+      expect(path).toBe('oauth-authorization-server/*rest');
+    });
+
+    it('registers a GET wildcard route for oauth-protected-resource', () => {
+      const Ctrl = createWellKnownController();
+      const proto = Ctrl.prototype as Record<string, unknown>;
+      const path = Reflect.getMetadata('path', proto.getProtectedResourceMetadataForPath as object);
+      expect(path).toBe('oauth-protected-resource/*rest');
+    });
+
+    it('authorization-server wildcard returns the same metadata as the exact route', () => {
+      const instance = makeInstance({ ...baseOptions, scopes: ['read'] });
+      expect(instance.getAuthorizationServerMetadataForPath()).toEqual(
+        instance.getAuthorizationServerMetadata(),
+      );
+    });
+
+    it('protected-resource wildcard rebuilds resource from serverUrl when the path matches', () => {
+      const instance = makeInstance(baseOptions); // resourceUrl defaults to serverUrl + /mcp
+      const meta = instance.getProtectedResourceMetadataForPath({
+        url: '/.well-known/oauth-protected-resource/mcp',
+      });
+      expect(meta.resource).toBe('https://auth.example.com/mcp');
+    });
+
+    it('protected-resource wildcard matches the configured resource path of a custom resourceUrl', () => {
+      const instance = makeInstance({
+        ...baseOptions,
+        resourceUrl: 'https://api.example.com/api/mcp',
+      });
+      const meta = instance.getProtectedResourceMetadataForPath({
+        url: '/.well-known/oauth-protected-resource/api/mcp',
+      });
+      expect(meta.resource).toBe('https://auth.example.com/api/mcp');
+    });
+
+    it('protected-resource wildcard keeps the default resource for non-matching paths', () => {
+      const instance = makeInstance(baseOptions);
+      const meta = instance.getProtectedResourceMetadataForPath({
+        url: '/.well-known/oauth-protected-resource/other',
+      });
+      expect(meta.resource).toBe('https://auth.example.com/mcp');
+    });
+
+    it('protected-resource wildcard prefers originalUrl over url (Express mounts)', () => {
+      const instance = makeInstance(baseOptions);
+      const meta = instance.getProtectedResourceMetadataForPath({
+        url: '/mcp',
+        originalUrl: '/.well-known/oauth-protected-resource/mcp',
+      });
+      expect(meta.resource).toBe('https://auth.example.com/mcp');
+    });
+  });
+
+  describe('buildWellKnownWildcardRoute()', () => {
+    it('uses named wildcards on Nest >= 11', () => {
+      expect(buildWellKnownWildcardRoute('oauth-authorization-server', 11)).toBe(
+        'oauth-authorization-server/*rest',
+      );
+      expect(buildWellKnownWildcardRoute('oauth-protected-resource', 12)).toBe(
+        'oauth-protected-resource/*rest',
+      );
+    });
+
+    it('uses a bare wildcard on Nest 10', () => {
+      expect(buildWellKnownWildcardRoute('oauth-authorization-server', 10)).toBe(
+        'oauth-authorization-server/*',
+      );
+    });
+  });
+
+  describe('extractWellKnownRest()', () => {
+    it('extracts a single-segment suffix', () => {
+      expect(
+        extractWellKnownRest(
+          '/.well-known/oauth-protected-resource/mcp',
+          'oauth-protected-resource',
+        ),
+      ).toBe('mcp');
+    });
+
+    it('extracts a multi-segment suffix', () => {
+      expect(
+        extractWellKnownRest(
+          '/.well-known/oauth-authorization-server/tenant/a',
+          'oauth-authorization-server',
+        ),
+      ).toBe('tenant/a');
+    });
+
+    it('strips the query string', () => {
+      expect(
+        extractWellKnownRest(
+          '/.well-known/oauth-protected-resource/mcp?foo=1',
+          'oauth-protected-resource',
+        ),
+      ).toBe('mcp');
+    });
+
+    it('decodes percent-encoded segments', () => {
+      expect(
+        extractWellKnownRest(
+          '/.well-known/oauth-protected-resource/my%20path',
+          'oauth-protected-resource',
+        ),
+      ).toBe('my path');
+    });
+
+    it('returns empty string when the marker is absent or url is undefined', () => {
+      expect(extractWellKnownRest('/somewhere/else', 'oauth-protected-resource')).toBe('');
+      expect(extractWellKnownRest(undefined, 'oauth-protected-resource')).toBe('');
     });
   });
 });

--- a/packages/server/src/auth/oauth/well-known.controller.ts
+++ b/packages/server/src/auth/oauth/well-known.controller.ts
@@ -1,37 +1,152 @@
-import { Controller, Get, type Type } from '@nestjs/common';
+import { Controller, Get, Inject, Req, type Type } from '@nestjs/common';
 import type { McpAuthModuleOptions } from '../interfaces/auth-module-options.interface';
+import { MCP_AUTH_OPTIONS } from '../services/jwt-token.service';
 
-export function createWellKnownController(options: McpAuthModuleOptions): Type<unknown> {
-  const serverUrl = options.serverUrl ?? 'http://localhost:3000';
-  const resourceUrl = options.resourceUrl ?? `${serverUrl}/mcp`;
+const DEFAULT_SERVER_URL = 'http://localhost:3000';
+
+/**
+ * Returns the Nest major version so route syntax can adapt: Nest 11
+ * (path-to-regexp v8) requires named wildcards (`*rest`) while Nest 10
+ * (legacy path-to-regexp) uses a bare `*`.
+ */
+function nestMajorVersion(): number {
+  try {
+    // The package builds to CommonJS, so `require` is available at runtime
+    // (the typeof check covers ESM-transformed test environments). Neither
+    // @nestjs/common@10 nor @11 restricts `./package.json` via exports.
+    if (typeof require !== 'function') return 11;
+    const { version } = require('@nestjs/common/package.json') as { version: string };
+    return Number.parseInt(version.split('.')[0] ?? '', 10) || 11;
+  } catch {
+    return 11;
+  }
+}
+
+/**
+ * Builds the RFC 8414/9728 path-insertion wildcard route for a well-known
+ * base path, using the wildcard syntax of the given Nest major version.
+ *
+ * Exported for tests only.
+ */
+export function buildWellKnownWildcardRoute(base: string, nestMajor: number): string {
+  return nestMajor >= 11 ? `${base}/*rest` : `${base}/*`;
+}
+
+/**
+ * Extracts the path-insertion suffix from a well-known request URL, e.g.
+ * `/.well-known/oauth-protected-resource/mcp` → `mcp`. Version-agnostic
+ * (reads the URL instead of route params, whose shape differs between
+ * Express 4 and Express 5).
+ *
+ * Exported for tests only.
+ */
+export function extractWellKnownRest(url: string | undefined, base: string): string {
+  if (!url) return '';
+  const marker = `/.well-known/${base}/`;
+  const index = url.indexOf(marker);
+  if (index === -1) return '';
+  const rest = url.slice(index + marker.length);
+  const queryIndex = rest.indexOf('?');
+  const path = queryIndex === -1 ? rest : rest.slice(0, queryIndex);
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+interface WellKnownRequest {
+  url?: string;
+  originalUrl?: string;
+}
+
+/**
+ * Builds the `.well-known` controller serving RFC 8414 authorization-server
+ * metadata and RFC 9728 protected-resource metadata, including the
+ * path-insertion variants (`/.well-known/<base>/<path>`).
+ *
+ * Options are constructor-injected via `MCP_AUTH_OPTIONS` (instead of closed
+ * over) so the controller also works with `McpAuthModule.forRootAsync`, where
+ * options only exist once the factory has run.
+ */
+export function createWellKnownController(): Type<unknown> {
+  const nestMajor = nestMajorVersion();
 
   @Controller('.well-known')
   class WellKnownController {
+    constructor(
+      @Inject(MCP_AUTH_OPTIONS)
+      private readonly options: McpAuthModuleOptions,
+    ) {}
+
+    private get serverUrl(): string {
+      return this.options.serverUrl ?? DEFAULT_SERVER_URL;
+    }
+
+    private get resourceUrl(): string {
+      return this.options.resourceUrl ?? `${this.serverUrl}/mcp`;
+    }
+
     @Get('oauth-authorization-server')
     getAuthorizationServerMetadata() {
+      const serverUrl = this.serverUrl;
+      const authMethods = ['client_secret_post', 'none'];
       return {
-        issuer: options.issuer ?? serverUrl,
+        issuer: this.options.issuer ?? serverUrl,
         authorization_endpoint: `${serverUrl}/authorize`,
         token_endpoint: `${serverUrl}/token`,
         registration_endpoint:
-          options.enableDynamicRegistration !== false ? `${serverUrl}/register` : undefined,
+          this.options.enableDynamicRegistration !== false ? `${serverUrl}/register` : undefined,
         revocation_endpoint: `${serverUrl}/revoke`,
+        revocation_endpoint_auth_methods_supported: authMethods,
+        introspection_endpoint: `${serverUrl}/introspect`,
+        introspection_endpoint_auth_methods_supported: authMethods,
         response_types_supported: ['code'],
         grant_types_supported: ['authorization_code', 'refresh_token'],
-        token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+        token_endpoint_auth_methods_supported: authMethods,
         code_challenge_methods_supported: ['S256', 'plain'],
-        scopes_supported: options.scopes ?? [],
+        scopes_supported: this.options.scopes ?? [],
       };
+    }
+
+    /** RFC 8414 path-insertion variant — same metadata for any issuer path. */
+    @Get(buildWellKnownWildcardRoute('oauth-authorization-server', nestMajor))
+    getAuthorizationServerMetadataForPath() {
+      return this.getAuthorizationServerMetadata();
     }
 
     @Get('oauth-protected-resource')
     getProtectedResourceMetadata() {
       return {
-        resource: resourceUrl,
-        authorization_servers: [options.issuer ?? serverUrl],
-        scopes_supported: options.scopes ?? [],
+        resource: this.resourceUrl,
+        authorization_servers: [this.options.issuer ?? this.serverUrl],
+        scopes_supported: this.options.scopes ?? [],
         bearer_methods_supported: ['header'],
       };
+    }
+
+    /**
+     * RFC 9728 path-insertion variant. When the inserted path matches the
+     * configured resource path, `resource` is rebuilt from it
+     * (`serverUrl + '/' + rest`); otherwise the default metadata is returned.
+     */
+    @Get(buildWellKnownWildcardRoute('oauth-protected-resource', nestMajor))
+    getProtectedResourceMetadataForPath(@Req() req: WellKnownRequest) {
+      const metadata = this.getProtectedResourceMetadata();
+      const rest = extractWellKnownRest(req.originalUrl ?? req.url, 'oauth-protected-resource');
+
+      const resourcePath = (() => {
+        try {
+          return new URL(this.resourceUrl).pathname.replace(/^\//, '');
+        } catch {
+          return '';
+        }
+      })();
+
+      if (rest && rest === resourcePath) {
+        return { ...metadata, resource: `${this.serverUrl}/${rest}` };
+      }
+      return metadata;
     }
   }
 

--- a/packages/server/src/auth/services/bearer-verifier.service.spec.ts
+++ b/packages/server/src/auth/services/bearer-verifier.service.spec.ts
@@ -1,0 +1,112 @@
+import 'reflect-metadata';
+import * as jwt from 'jsonwebtoken';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IOAuthStore } from '../stores/oauth-store.interface';
+import { JwtBearerTokenVerifier } from './bearer-verifier.service';
+import { JwtTokenService } from './jwt-token.service';
+
+const secret = 'test-jwt-secret-key-for-unit-tests';
+
+function makeStore(overrides: Partial<Record<keyof IOAuthStore, ReturnType<typeof vi.fn>>> = {}) {
+  return {
+    storeClient: vi.fn(),
+    getClient: vi.fn(),
+    storeAuthCode: vi.fn(),
+    getAuthCode: vi.fn(),
+    removeAuthCode: vi.fn(),
+    revokeToken: vi.fn().mockResolvedValue(undefined),
+    isTokenRevoked: vi.fn().mockResolvedValue(false),
+    ...overrides,
+  };
+}
+
+function makeVerifier(store = makeStore()) {
+  const jwtService = new JwtTokenService({ jwtSecret: secret });
+  return { verifier: new JwtBearerTokenVerifier(jwtService, store as never), store };
+}
+
+function signAccessToken(claims: Record<string, unknown> = {}, expiresIn = 3600): string {
+  return jwt.sign(
+    { sub: 'user-1', azp: 'client-1', type: 'access', iss: 'test', ...claims },
+    secret,
+    { expiresIn, algorithm: 'HS256' },
+  );
+}
+
+describe('JwtBearerTokenVerifier', () => {
+  let verifier: JwtBearerTokenVerifier;
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    ({ verifier, store } = makeVerifier());
+  });
+
+  it('returns McpAuthInfo for a valid access token', async () => {
+    const token = signAccessToken({ scope: 'read write' });
+
+    const result = await verifier.verify(token);
+
+    expect(result).toEqual({
+      token,
+      clientId: 'client-1',
+      scopes: ['read', 'write'],
+      expiresAt: expect.any(Number),
+      extra: { sub: 'user-1' },
+    });
+  });
+
+  it('falls back to client_id when azp is absent', async () => {
+    const token = signAccessToken({ azp: undefined, client_id: 'client-2' });
+
+    const result = await verifier.verify(token);
+
+    expect(result?.clientId).toBe('client-2');
+  });
+
+  it('returns empty clientId and scopes when claims are absent', async () => {
+    const token = signAccessToken({ azp: undefined });
+
+    const result = await verifier.verify(token);
+
+    expect(result?.clientId).toBe('');
+    expect(result?.scopes).toEqual([]);
+  });
+
+  it('returns null for an expired token', async () => {
+    const token = signAccessToken({}, -10);
+
+    expect(await verifier.verify(token)).toBeNull();
+  });
+
+  it('returns null for a token signed with the wrong secret', async () => {
+    const token = jwt.sign({ sub: 'u', type: 'access' }, 'another-secret', { algorithm: 'HS256' });
+
+    expect(await verifier.verify(token)).toBeNull();
+  });
+
+  it('returns null for a refresh token', async () => {
+    const token = signAccessToken({ type: 'refresh', jti: 'jti-1' });
+
+    expect(await verifier.verify(token)).toBeNull();
+  });
+
+  it('returns null for a revoked token and checks the store with the jti', async () => {
+    store.isTokenRevoked.mockResolvedValue(true);
+    const token = signAccessToken({ jti: 'jti-revoked' });
+
+    expect(await verifier.verify(token)).toBeNull();
+    expect(store.isTokenRevoked).toHaveBeenCalledWith('jti-revoked');
+  });
+
+  it('skips the revocation check when the token has no jti', async () => {
+    const token = signAccessToken();
+
+    expect(await verifier.verify(token)).not.toBeNull();
+    expect(store.isTokenRevoked).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a garbage token', async () => {
+    expect(await verifier.verify('not.a.token')).toBeNull();
+    expect(await verifier.verify('')).toBeNull();
+  });
+});

--- a/packages/server/src/auth/services/bearer-verifier.service.ts
+++ b/packages/server/src/auth/services/bearer-verifier.service.ts
@@ -1,0 +1,46 @@
+import type { McpAuthInfo } from '@nest-mcp/common';
+import { Inject, Injectable } from '@nestjs/common';
+import type { TokenPayload } from '../interfaces/oauth-types.interface';
+import type { IOAuthStore } from '../stores/oauth-store.interface';
+import { MCP_OAUTH_STORE } from './client.service';
+import { JwtTokenService } from './jwt-token.service';
+
+export const MCP_BEARER_TOKEN_VERIFIER = Symbol('MCP_BEARER_TOKEN_VERIFIER');
+
+/**
+ * Verifies a raw bearer token presented at the HTTP edge. Host apps can
+ * override the default JWT implementation by re-providing
+ * `MCP_BEARER_TOKEN_VERIFIER` (e.g. for opaque-token introspection).
+ */
+export interface BearerTokenVerifier {
+  /** Returns the verified identity, or `null` when the token is invalid. */
+  verify(token: string): Promise<McpAuthInfo | null>;
+}
+
+@Injectable()
+export class JwtBearerTokenVerifier implements BearerTokenVerifier {
+  constructor(
+    private readonly jwtService: JwtTokenService,
+    @Inject(MCP_OAUTH_STORE) private readonly store: IOAuthStore,
+  ) {}
+
+  async verify(token: string): Promise<McpAuthInfo | null> {
+    let payload: TokenPayload;
+    try {
+      payload = this.jwtService.validateToken(token);
+    } catch {
+      return null;
+    }
+
+    if (payload.type !== 'access') return null;
+    if (payload.jti && (await this.store.isTokenRevoked(payload.jti))) return null;
+
+    return {
+      token,
+      clientId: payload.azp ?? payload.client_id ?? '',
+      scopes: (payload.scope ?? '').split(' ').filter(Boolean),
+      expiresAt: payload.exp,
+      extra: { sub: payload.sub },
+    };
+  }
+}

--- a/packages/server/src/auth/services/jwt-token.service.spec.ts
+++ b/packages/server/src/auth/services/jwt-token.service.spec.ts
@@ -71,6 +71,52 @@ describe('JwtTokenService', () => {
       expect(decodedDefault.aud).toBe('mcp-client');
     });
 
+    it('binds aud to the requested resource (RFC 8707), beating options.audience', () => {
+      const service = createService({ audience: 'my-audience' });
+      const result = service.generateTokenPair(
+        'user-1',
+        'client-1',
+        'read',
+        'https://api.example.com/mcp',
+      );
+
+      const decoded = jwt.decode(result.access_token) as Record<string, unknown>;
+      expect(decoded.aud).toBe('https://api.example.com/mcp');
+    });
+
+    it('falls back to options.audience when no resource is requested', () => {
+      const service = createService({ audience: 'my-audience' });
+      const result = service.generateTokenPair('user-1', 'client-1', 'read', undefined);
+
+      const decoded = jwt.decode(result.access_token) as Record<string, unknown>;
+      expect(decoded.aud).toBe('my-audience');
+    });
+
+    it('does not enforce aud in validateToken (non-breaking)', () => {
+      const service = createService({ audience: 'expected-audience' });
+      const result = service.generateTokenPair(
+        'user-1',
+        'client-1',
+        'read',
+        'https://api.example.com/mcp',
+      );
+
+      // Token aud is the resource, not options.audience — still validates.
+      expect(() => service.validateToken(result.access_token)).not.toThrow();
+    });
+
+    it('sets a unique jti on access tokens', () => {
+      const service = createService();
+      const a = service.generateTokenPair('user-1', 'client-1');
+      const b = service.generateTokenPair('user-1', 'client-1');
+
+      const decodedA = jwt.decode(a.access_token) as Record<string, unknown>;
+      const decodedB = jwt.decode(b.access_token) as Record<string, unknown>;
+      expect(decodedA.jti).toEqual(expect.any(String));
+      expect(decodedB.jti).toEqual(expect.any(String));
+      expect(decodedA.jti).not.toBe(decodedB.jti);
+    });
+
     it('sets sub and azp on access token', () => {
       const service = createService();
       const result = service.generateTokenPair('user-42', 'client-99');

--- a/packages/server/src/auth/services/jwt-token.service.spec.ts
+++ b/packages/server/src/auth/services/jwt-token.service.spec.ts
@@ -138,6 +138,14 @@ describe('JwtTokenService', () => {
       expect(decoded.jti).toEqual(expect.any(String));
     });
 
+    it('includes scope in the refresh token payload so the refresh grant can preserve it', () => {
+      const service = createService();
+      const result = service.generateTokenPair('user-1', 'client-1', 'read write');
+
+      const decoded = jwt.decode(result.refresh_token) as Record<string, unknown>;
+      expect(decoded.scope).toBe('read write');
+    });
+
     it('respects accessTokenExpiresIn option', () => {
       const service = createService({ accessTokenExpiresIn: '2h' });
       const result = service.generateTokenPair('user-1', 'client-1');

--- a/packages/server/src/auth/services/jwt-token.service.ts
+++ b/packages/server/src/auth/services/jwt-token.service.ts
@@ -21,7 +21,10 @@ export class JwtTokenService {
     resource?: string,
   ): TokenResponse {
     const iss = this.options.issuer ?? this.options.serverUrl ?? 'http://localhost:3000';
-    const aud = this.options.audience ?? 'mcp-client';
+    // RFC 8707: when the client requested a specific resource, bind the token
+    // to it via `aud`. Note `validateToken` deliberately does NOT enforce
+    // `aud` (non-breaking); resource servers may verify it themselves.
+    const aud = resource ?? this.options.audience ?? 'mcp-client';
 
     const accessExpiresIn = parseDurationSeconds(this.options.accessTokenExpiresIn ?? '1d', 86400);
     const refreshExpiresIn = parseDurationSeconds(
@@ -37,6 +40,9 @@ export class JwtTokenService {
         scope,
         iss,
         aud,
+        // jti makes access tokens individually revocable and lets
+        // `IOAuthStore.recordIssuedToken` track them.
+        jti: randomUUID(),
       } as TokenPayload,
       this.options.jwtSecret,
       {

--- a/packages/server/src/auth/services/jwt-token.service.ts
+++ b/packages/server/src/auth/services/jwt-token.service.ts
@@ -56,6 +56,9 @@ export class JwtTokenService {
         sub: userId,
         client_id: clientId,
         type: 'refresh',
+        // Carry scope so the refresh grant can re-mint access tokens with the
+        // original scope (oauth-flow reads payload.scope on refresh).
+        scope,
         jti: randomUUID(),
         iss,
       } as TokenPayload,

--- a/packages/server/src/auth/services/oauth-flow.service.spec.ts
+++ b/packages/server/src/auth/services/oauth-flow.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { McpAuthModuleOptions } from '../interfaces/auth-module-options.interface';
 import type { AuthorizeQueryDto, TokenPayload } from '../interfaces/oauth-types.interface';
+import { JwtTokenService } from './jwt-token.service';
 import { OAuthFlowService } from './oauth-flow.service';
 
 // ─── Shared Setup ─────────────────────────────────────────────────────────────
@@ -367,6 +368,49 @@ describe('OAuthFlowService - refreshToken (refresh_token grant)', () => {
 
     expect(result.access_token).toBe('at');
     expect(store.revokeToken).toHaveBeenCalledWith('old-jti');
+  });
+
+  it('re-mints the access token with the scope carried on the refresh token', async () => {
+    jwtService.validateToken.mockReturnValue({
+      type: 'refresh',
+      jti: 'old-jti',
+      sub: 'user-1',
+      client_id: 'client-1',
+      scope: 'tools:read tools:write',
+    });
+
+    await service.refreshToken({ refresh_token: 'valid-rt' });
+
+    expect(jwtService.generateTokenPair).toHaveBeenCalledWith(
+      'user-1',
+      'client-1',
+      'tools:read tools:write',
+    );
+  });
+
+  it('preserves the original scope end-to-end with a real JwtTokenService', async () => {
+    // No jwt mocks here: mint a real pair, run the refresh grant, and verify
+    // the refreshed access token still carries the originally granted scope.
+    const options: McpAuthModuleOptions = { jwtSecret: 'x'.repeat(32) };
+    const realJwt = new JwtTokenService(options);
+    const realService = new OAuthFlowService(
+      options,
+      realJwt,
+      { getClient: vi.fn(), registerClient: vi.fn() } as never,
+      {
+        isTokenRevoked: vi.fn().mockResolvedValue(false),
+        revokeToken: vi.fn().mockResolvedValue(undefined),
+      } as never,
+    );
+
+    const original = realJwt.generateTokenPair('user-1', 'client-1', 'tools:read tools:write');
+    const refreshed = await realService.refreshToken({
+      refresh_token: original.refresh_token,
+    });
+
+    expect(realJwt.validateToken(refreshed.access_token).scope).toBe('tools:read tools:write');
+    // The new refresh token carries scope too, so chained refreshes keep it.
+    expect(realJwt.validateToken(refreshed.refresh_token).scope).toBe('tools:read tools:write');
   });
 
   it('skips revokeToken when refresh token has no jti', async () => {

--- a/packages/server/src/auth/services/oauth-flow.service.spec.ts
+++ b/packages/server/src/auth/services/oauth-flow.service.spec.ts
@@ -13,6 +13,7 @@ function makeService(
     getClient: ReturnType<typeof vi.fn>;
     registerClient: ReturnType<typeof vi.fn>;
   }> = {},
+  storeOverrides: Record<string, ReturnType<typeof vi.fn>> = {},
 ) {
   const options: McpAuthModuleOptions = {
     jwtSecret: 'x'.repeat(32),
@@ -37,6 +38,7 @@ function makeService(
     getAuthCode: vi.fn().mockResolvedValue(null),
     removeAuthCode: vi.fn().mockResolvedValue(undefined),
     storeAuthCode: vi.fn().mockResolvedValue(undefined),
+    ...storeOverrides,
   };
 
   const clientService = {
@@ -379,6 +381,157 @@ describe('OAuthFlowService - refreshToken (refresh_token grant)', () => {
 
     expect(result.access_token).toBe('at');
     expect(store.revokeToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('OAuthFlowService - recordIssuedToken store hook', () => {
+  const accessPayload: Partial<TokenPayload> = {
+    sub: 'user-1',
+    type: 'access',
+    jti: 'access-jti',
+    scope: 'tools:read',
+    exp: 1_000,
+    iss: 'test',
+  };
+  const refreshPayload: Partial<TokenPayload> = {
+    sub: 'user-1',
+    type: 'refresh',
+    jti: 'refresh-jti',
+    exp: 2_000,
+    iss: 'test',
+  };
+
+  function makeRecordingService(
+    extraStoreOverrides: Record<string, ReturnType<typeof vi.fn>> = {},
+  ) {
+    return makeService(
+      {},
+      {},
+      { recordIssuedToken: vi.fn().mockResolvedValue(undefined), ...extraStoreOverrides },
+    );
+  }
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('records both minted tokens on the authorization_code grant', async () => {
+    const { service, jwtService, store } = makeRecordingService({
+      getAuthCode: vi.fn().mockResolvedValue({
+        code_challenge: 'exact-verifier',
+        code_challenge_method: 'plain',
+        redirect_uri: 'https://app/cb',
+        user_id: 'user-1',
+        client_id: 'client-1',
+        scope: 'tools:read',
+      }),
+    });
+    jwtService.validateToken.mockImplementation((token: string) =>
+      token === 'at' ? accessPayload : refreshPayload,
+    );
+
+    await service.exchangeCode({ code: 'c', code_verifier: 'exact-verifier' });
+
+    expect(store.recordIssuedToken).toHaveBeenCalledTimes(2);
+    expect(store.recordIssuedToken).toHaveBeenCalledWith({
+      jti: 'access-jti',
+      type: 'access',
+      clientId: 'client-1',
+      userId: 'user-1',
+      scope: 'tools:read',
+      expiresAt: 1_000_000,
+    });
+    expect(store.recordIssuedToken).toHaveBeenCalledWith({
+      jti: 'refresh-jti',
+      type: 'refresh',
+      clientId: 'client-1',
+      userId: 'user-1',
+      scope: undefined,
+      expiresAt: 2_000_000,
+    });
+  });
+
+  it('records both minted tokens on the refresh_token grant', async () => {
+    const { service, jwtService, store } = makeRecordingService();
+    jwtService.validateToken.mockImplementation((token: string) => {
+      if (token === 'valid-rt') {
+        return {
+          type: 'refresh',
+          jti: 'old-jti',
+          sub: 'user-1',
+          azp: 'client-1',
+          scope: 'tools:read',
+        };
+      }
+      return token === 'at' ? accessPayload : refreshPayload;
+    });
+
+    await service.refreshToken({ refresh_token: 'valid-rt' });
+
+    expect(store.recordIssuedToken).toHaveBeenCalledTimes(2);
+    expect(store.recordIssuedToken).toHaveBeenCalledWith(
+      expect.objectContaining({ jti: 'access-jti', type: 'access', clientId: 'client-1' }),
+    );
+    expect(store.recordIssuedToken).toHaveBeenCalledWith(
+      expect.objectContaining({ jti: 'refresh-jti', type: 'refresh', clientId: 'client-1' }),
+    );
+  });
+
+  it('does not record tokens when the presented refresh jti is revoked', async () => {
+    const { service, jwtService, store } = makeRecordingService({
+      isTokenRevoked: vi.fn().mockResolvedValue(true),
+    });
+    jwtService.validateToken.mockReturnValue({ type: 'refresh', jti: 'revoked-jti', sub: 'u' });
+
+    await expect(service.refreshToken({ refresh_token: 'revoked-rt' })).rejects.toMatchObject({
+      status: HttpStatus.UNAUTHORIZED,
+    });
+    expect(store.recordIssuedToken).not.toHaveBeenCalled();
+  });
+
+  it('skips minted tokens without a jti', async () => {
+    const { service, jwtService, store } = makeRecordingService({
+      getAuthCode: vi.fn().mockResolvedValue({
+        code_challenge: 'exact-verifier',
+        code_challenge_method: 'plain',
+        redirect_uri: 'https://app/cb',
+        user_id: 'user-1',
+        client_id: 'client-1',
+        scope: '',
+      }),
+    });
+    jwtService.validateToken.mockImplementation((token: string) =>
+      token === 'at' ? { ...accessPayload, jti: undefined } : refreshPayload,
+    );
+
+    await service.exchangeCode({ code: 'c', code_verifier: 'exact-verifier' });
+
+    expect(store.recordIssuedToken).toHaveBeenCalledTimes(1);
+    expect(store.recordIssuedToken).toHaveBeenCalledWith(
+      expect.objectContaining({ jti: 'refresh-jti', type: 'refresh' }),
+    );
+  });
+
+  it('is a no-op for stores without the hook (backward compatible)', async () => {
+    const { service, jwtService, store } = makeService(
+      {},
+      {},
+      {
+        getAuthCode: vi.fn().mockResolvedValue({
+          code_challenge: 'exact-verifier',
+          code_challenge_method: 'plain',
+          redirect_uri: 'https://app/cb',
+          user_id: 'user-1',
+          client_id: 'client-1',
+          scope: '',
+        }),
+      },
+    );
+
+    const result = await service.exchangeCode({ code: 'c', code_verifier: 'exact-verifier' });
+
+    expect(result.access_token).toBe('at');
+    expect('recordIssuedToken' in store).toBe(false);
+    // Minted tokens are never re-validated when no hook is present.
+    expect(jwtService.validateToken).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/server/src/auth/services/oauth-flow.service.ts
+++ b/packages/server/src/auth/services/oauth-flow.service.ts
@@ -209,6 +209,7 @@ export class OAuthFlowService {
       authCode.scope,
       authCode.resource,
     );
+    await this.recordIssuedTokens(tokenResponse, authCode.client_id);
     this.auditService?.logTokenIssued(authCode.client_id, authCode.user_id);
     return tokenResponse;
   }
@@ -242,8 +243,35 @@ export class OAuthFlowService {
 
     const clientId = payload.client_id ?? payload.azp ?? '';
     const refreshResponse = this.jwtService.generateTokenPair(payload.sub, clientId, payload.scope);
+    await this.recordIssuedTokens(refreshResponse, clientId);
     this.auditService?.logTokenIssued(clientId, payload.sub);
     return refreshResponse;
+  }
+
+  /**
+   * Notifies the store of freshly minted tokens via the optional
+   * `recordIssuedToken` hook so host apps can track/revoke refresh chains.
+   * No-op when the store does not implement the hook.
+   */
+  private async recordIssuedTokens(tokens: TokenResponse, clientId: string): Promise<void> {
+    if (typeof this.store.recordIssuedToken !== 'function') return;
+
+    const minted = [
+      { type: 'access' as const, token: tokens.access_token },
+      { type: 'refresh' as const, token: tokens.refresh_token },
+    ];
+    for (const { type, token } of minted) {
+      const payload = this.jwtService.validateToken(token);
+      if (!payload.jti) continue;
+      await this.store.recordIssuedToken({
+        jti: payload.jti,
+        type,
+        clientId,
+        userId: payload.sub,
+        scope: payload.scope,
+        expiresAt: (payload.exp ?? 0) * 1000,
+      });
+    }
   }
 
   async revokeToken(body: Record<string, unknown>): Promise<{ success: boolean }> {

--- a/packages/server/src/auth/stores/oauth-store.interface.ts
+++ b/packages/server/src/auth/stores/oauth-store.interface.ts
@@ -1,5 +1,17 @@
 import type { AuthorizationCode, OAuthClient } from '../interfaces/oauth-types.interface';
 
+/** Record passed to `IOAuthStore.recordIssuedToken` whenever a token is minted. */
+export interface IssuedTokenRecord {
+  /** JWT ID of the minted token. */
+  jti: string;
+  type: 'access' | 'refresh';
+  clientId: string;
+  userId?: string;
+  scope?: string;
+  /** Expiry as unix epoch milliseconds. */
+  expiresAt: number;
+}
+
 export interface IOAuthStore {
   storeClient(client: OAuthClient): Promise<OAuthClient>;
   getClient(clientId: string): Promise<OAuthClient | undefined>;
@@ -8,4 +20,10 @@ export interface IOAuthStore {
   removeAuthCode(code: string): Promise<void>;
   revokeToken(jti: string): Promise<void>;
   isTokenRevoked(jti: string): Promise<boolean>;
+  /**
+   * Optional hook invoked whenever an access or refresh token is minted
+   * (initial authorization-code grant and refresh grant). Lets host apps
+   * track issued tokens — e.g. to revoke whole refresh chains.
+   */
+  recordIssuedToken?(rec: IssuedTokenRecord): void | Promise<void>;
 }

--- a/packages/server/src/execution/pipeline.service.spec.ts
+++ b/packages/server/src/execution/pipeline.service.spec.ts
@@ -21,12 +21,14 @@ describe('ExecutionPipelineService', () => {
   let moduleRef: Record<string, ReturnType<typeof vi.fn>>;
   let options: McpModuleOptions;
   let requestContext: McpRequestContextService;
+  let exposure: Record<string, ReturnType<typeof vi.fn>>;
 
   beforeEach(() => {
     ctx = mockMcpContext();
 
     executor = {
       callTool: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+      buildToolEntries: vi.fn().mockReturnValue([]),
       listTools: vi.fn().mockResolvedValue([]),
       listResources: vi.fn().mockResolvedValue([]),
       listResourceTemplates: vi.fn().mockResolvedValue([]),
@@ -39,6 +41,10 @@ describe('ExecutionPipelineService', () => {
       getTool: vi.fn(),
       getResource: vi.fn(),
       getPrompt: vi.fn(),
+      getAllTools: vi.fn().mockReturnValue([]),
+      getAllResources: vi.fn().mockReturnValue([]),
+      getAllResourceTemplates: vi.fn().mockReturnValue([]),
+      getAllPrompts: vi.fn().mockReturnValue([]),
     };
 
     authGuard = {
@@ -70,6 +76,9 @@ describe('ExecutionPipelineService', () => {
 
     options = {} as McpModuleOptions;
     requestContext = new McpRequestContextService();
+    exposure = {
+      applyStrategy: vi.fn().mockImplementation((entries: unknown[]) => entries),
+    };
 
     pipeline = new ExecutionPipelineService(
       executor as unknown as ConstructorParameters<typeof ExecutionPipelineService>[0],
@@ -83,6 +92,7 @@ describe('ExecutionPipelineService', () => {
       options,
       moduleRef as unknown as ConstructorParameters<typeof ExecutionPipelineService>[9],
       requestContext,
+      exposure as unknown as ConstructorParameters<typeof ExecutionPipelineService>[11],
     );
   });
 
@@ -351,6 +361,33 @@ describe('ExecutionPipelineService', () => {
       );
     });
 
+    it('exposes authInfo on the guard context', async () => {
+      const mockGuard = { canActivate: vi.fn().mockResolvedValue(true) };
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      options.guards = [class {} as any];
+      moduleRef.get.mockReturnValue(mockGuard);
+      registry.getTool.mockReturnValue({ name: 'test', isPublic: true });
+      const authInfo = { token: 't', clientId: 'client-1', scopes: ['tools:read'] };
+      const authedCtx = mockMcpContext({ authInfo });
+
+      await pipeline.callTool('test', {}, authedCtx);
+
+      expect(mockGuard.canActivate).toHaveBeenCalledWith(expect.objectContaining({ authInfo }));
+    });
+
+    it('exposes authInfo on the tool-auth guard context', async () => {
+      registry.getTool.mockReturnValue({ name: 'priv', isPublic: false });
+      const authInfo = { token: 't', clientId: 'client-1', scopes: ['tools:read'] };
+      const authedCtx = mockMcpContext({ authInfo });
+
+      await pipeline.callTool('priv', {}, authedCtx);
+
+      expect(authGuard.checkAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'priv' }),
+        expect.objectContaining({ authInfo }),
+      );
+    });
+
     it('instantiates guard directly when not found in DI', async () => {
       const canActivate = vi.fn().mockResolvedValue(true);
       const GuardClass = class SimpleGuard {
@@ -584,6 +621,194 @@ describe('ExecutionPipelineService', () => {
       const result = await pipeline.listPrompts();
 
       expect(result).toBe(expected);
+    });
+
+    it('listTools applies the exposure strategy when a client context is given', async () => {
+      const entries = [{ name: 'a' }];
+      executor.buildToolEntries.mockReturnValue(entries);
+      exposure.applyStrategy.mockReturnValue([{ name: 'a' }]);
+      const clientCtx = { transport: 'stdio' as never };
+
+      const result = await pipeline.listTools(undefined, clientCtx);
+
+      expect(exposure.applyStrategy).toHaveBeenCalledWith(entries, expect.any(Map), clientCtx);
+      expect(result.items).toEqual([{ name: 'a' }]);
+    });
+  });
+
+  // --- scope-filtered lists (filterListsByScopes) ---
+
+  describe('filterListsByScopes', () => {
+    beforeEach(() => {
+      options.filterListsByScopes = true;
+    });
+
+    describe('listTools', () => {
+      beforeEach(() => {
+        registry.getAllTools.mockReturnValue([
+          { name: 'open', description: 'Open' },
+          { name: 'scoped', description: 'Scoped', requiredScopes: ['admin'] },
+        ]);
+        executor.buildToolEntries.mockReturnValue([{ name: 'open' }, { name: 'scoped' }]);
+      });
+
+      it('hides tools whose required scopes are not covered', async () => {
+        const result = await pipeline.listTools(undefined, undefined, { scopes: ['user'] });
+
+        expect(result.items).toEqual([{ name: 'open' }]);
+        expect(executor.listTools).not.toHaveBeenCalled();
+      });
+
+      it('keeps scoped tools when the caller has all required scopes', async () => {
+        const result = await pipeline.listTools(undefined, undefined, { scopes: ['admin'] });
+
+        expect(result.items).toEqual([{ name: 'open' }, { name: 'scoped' }]);
+      });
+
+      it('shows only unscoped tools to unauthenticated callers', async () => {
+        const result = await pipeline.listTools();
+
+        expect(result.items).toEqual([{ name: 'open' }]);
+      });
+
+      it('keeps exposure meta-tools that have no registry meta', async () => {
+        exposure.applyStrategy.mockReturnValue([{ name: 'scoped' }, { name: 'search_tools' }]);
+        const clientCtx = { transport: 'stdio' as never };
+
+        const result = await pipeline.listTools(undefined, clientCtx, { scopes: [] });
+
+        expect(result.items).toEqual([{ name: 'search_tools' }]);
+      });
+    });
+
+    describe('listResources', () => {
+      beforeEach(() => {
+        registry.getAllResources.mockReturnValue([
+          { uri: 'file:///open', name: 'open' },
+          { uri: 'file:///secret', name: 'secret', requiredScopes: ['admin'] },
+        ]);
+      });
+
+      it('hides resources whose required scopes are not covered', async () => {
+        const result = await pipeline.listResources(undefined, { scopes: [] });
+
+        expect(result.items).toEqual([{ uri: 'file:///open', name: 'open' }]);
+        expect(executor.listResources).not.toHaveBeenCalled();
+      });
+
+      it('keeps scoped resources when the caller has all required scopes', async () => {
+        const result = await pipeline.listResources(undefined, { scopes: ['admin'] });
+
+        expect(result.items).toEqual([
+          { uri: 'file:///open', name: 'open' },
+          { uri: 'file:///secret', name: 'secret' },
+        ]);
+      });
+
+      it('mirrors the executor entry shape', async () => {
+        registry.getAllResources.mockReturnValue([
+          {
+            uri: 'file:///doc',
+            name: 'doc',
+            title: 'Doc',
+            description: 'A doc',
+            mimeType: 'text/plain',
+          },
+        ]);
+
+        const result = await pipeline.listResources(undefined, { scopes: [] });
+
+        expect(result.items).toEqual([
+          {
+            uri: 'file:///doc',
+            name: 'doc',
+            title: 'Doc',
+            description: 'A doc',
+            mimeType: 'text/plain',
+          },
+        ]);
+      });
+
+      it('delegates unchanged when the flag is off', async () => {
+        options.filterListsByScopes = false;
+        const expected = { items: [{ uri: 'x' }] };
+        executor.listResources.mockResolvedValue(expected);
+
+        const result = await pipeline.listResources(undefined, { scopes: [] });
+
+        expect(result).toBe(expected);
+        expect(executor.listResources).toHaveBeenCalledWith(undefined);
+      });
+    });
+
+    describe('listResourceTemplates', () => {
+      beforeEach(() => {
+        registry.getAllResourceTemplates.mockReturnValue([
+          { uriTemplate: 'data://open/{id}', name: 'open' },
+          { uriTemplate: 'data://secret/{id}', name: 'secret', requiredScopes: ['admin'] },
+        ]);
+      });
+
+      it('hides templates whose required scopes are not covered', async () => {
+        const result = await pipeline.listResourceTemplates(undefined, { scopes: [] });
+
+        expect(result.items).toEqual([{ uriTemplate: 'data://open/{id}', name: 'open' }]);
+        expect(executor.listResourceTemplates).not.toHaveBeenCalled();
+      });
+
+      it('keeps scoped templates when the caller has all required scopes', async () => {
+        const result = await pipeline.listResourceTemplates(undefined, { scopes: ['admin'] });
+
+        expect(result.items).toEqual([
+          { uriTemplate: 'data://open/{id}', name: 'open' },
+          { uriTemplate: 'data://secret/{id}', name: 'secret' },
+        ]);
+      });
+
+      it('delegates unchanged when the flag is off', async () => {
+        options.filterListsByScopes = false;
+        const expected = { items: [{ uriTemplate: 'x' }] };
+        executor.listResourceTemplates.mockResolvedValue(expected);
+
+        const result = await pipeline.listResourceTemplates(undefined, { scopes: [] });
+
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('listPrompts', () => {
+      beforeEach(() => {
+        registry.getAllPrompts.mockReturnValue([
+          { name: 'open', description: 'Open prompt' },
+          { name: 'secret', description: 'Secret prompt', requiredScopes: ['admin'] },
+        ]);
+      });
+
+      it('hides prompts whose required scopes are not covered', async () => {
+        const result = await pipeline.listPrompts(undefined, { scopes: [] });
+
+        expect(result.items).toEqual([{ name: 'open', description: 'Open prompt' }]);
+        expect(executor.listPrompts).not.toHaveBeenCalled();
+      });
+
+      it('keeps scoped prompts when the caller has all required scopes', async () => {
+        const result = await pipeline.listPrompts(undefined, { scopes: ['admin'] });
+
+        expect(result.items).toEqual([
+          { name: 'open', description: 'Open prompt' },
+          { name: 'secret', description: 'Secret prompt' },
+        ]);
+      });
+
+      it('delegates unchanged when the flag is off', async () => {
+        options.filterListsByScopes = false;
+        const expected = { items: [{ name: 'p' }] };
+        executor.listPrompts.mockResolvedValue(expected);
+
+        const result = await pipeline.listPrompts(undefined, { scopes: [] });
+
+        expect(result).toBe(expected);
+      });
     });
   });
 

--- a/packages/server/src/execution/pipeline.service.ts
+++ b/packages/server/src/execution/pipeline.service.ts
@@ -13,13 +13,13 @@ import type {
   ToolCallResult,
   ToolMetadata,
 } from '@nest-mcp/common';
-import type { McpGuard, McpGuardClass } from '@nest-mcp/common';
 import {
   MCP_OPTIONS,
   MCP_REQUEST_CANCELLED,
   McpError,
   McpTimeoutError,
   ToolExecutionError,
+  extractZodDescriptions,
   paginate,
 } from '@nest-mcp/common';
 import { Inject, Injectable, Logger } from '@nestjs/common';
@@ -32,8 +32,23 @@ import { MetricsService } from '../observability/metrics.service';
 import { CircuitBreakerService } from '../resilience/circuit-breaker.service';
 import { RateLimiterService } from '../resilience/rate-limiter.service';
 import { RetryService } from '../resilience/retry.service';
+import { resolveGuard } from '../utils/resolve-guard.util';
 import { McpExecutorService } from './executor.service';
 import { McpRequestContextService } from './request-context.service';
+
+/** Caller identity used to scope-filter list results. */
+export interface ListAuthContext {
+  scopes?: string[];
+}
+
+/**
+ * Structural read of `requiredScopes` from a registry item. Resource and
+ * prompt metadata don't declare auth fields in their interfaces (yet), but
+ * the filter must honor them when present at runtime.
+ */
+function requiredScopesOf(item: object): string[] | undefined {
+  return (item as { requiredScopes?: string[] }).requiredScopes;
+}
 
 @Injectable()
 export class ExecutionPipelineService {
@@ -190,30 +205,94 @@ export class ExecutionPipelineService {
 
   // ---- List methods (delegate directly) ----
 
-  async listTools(cursor?: string, ctx?: ClientContext) {
-    // When a client context is supplied, apply the exposure strategy before
-    // paginating so filtered strategies (e.g. `lazy`) produce even page sizes.
-    if (!ctx) {
+  async listTools(cursor?: string, ctx?: ClientContext, auth?: ListAuthContext) {
+    const filterByScopes = this.options.filterListsByScopes === true;
+    if (!ctx && !filterByScopes) {
       return this.executor.listTools(cursor);
     }
+    // When a client context is supplied, apply the exposure strategy before
+    // paginating so filtered strategies (e.g. `lazy`) produce even page sizes.
     const entries = this.executor.buildToolEntries();
     const metaMap = new Map<string, ToolMetadata>(
       this.registry.getAllTools().map((t) => [t.name, t]),
     );
-    const shaped = this.exposure.applyStrategy(entries, metaMap, ctx);
-    return paginate(shaped, cursor, this.options.pagination?.defaultPageSize);
+    const shaped = ctx ? this.exposure.applyStrategy(entries, metaMap, ctx) : entries;
+    // Meta-tools injected by exposure strategies have no registry meta (and
+    // thus no requiredScopes), so they survive the scope filter.
+    const visible = filterByScopes
+      ? shaped.filter((entry) =>
+          this.hasRequiredScopes(metaMap.get(entry.name)?.requiredScopes, auth?.scopes),
+        )
+      : shaped;
+    return paginate(visible, cursor, this.options.pagination?.defaultPageSize);
   }
 
-  async listResources(cursor?: string) {
-    return this.executor.listResources(cursor);
+  async listResources(cursor?: string, auth?: ListAuthContext) {
+    if (!this.options.filterListsByScopes) {
+      return this.executor.listResources(cursor);
+    }
+    // Mirrors McpExecutorService.listResources, with scope filtering applied
+    // before pagination so pages stay evenly sized.
+    const entries = this.registry
+      .getAllResources()
+      .filter((r) => this.hasRequiredScopes(requiredScopesOf(r), auth?.scopes))
+      .map((r) => ({
+        uri: r.uri,
+        name: r.name,
+        ...(r.title != null ? { title: r.title } : {}),
+        ...(r.description ? { description: r.description } : {}),
+        ...(r.mimeType ? { mimeType: r.mimeType } : {}),
+        ...(r.icons ? { icons: r.icons } : {}),
+        ...(r._meta ? { _meta: r._meta } : {}),
+      }));
+    return paginate(entries, cursor, this.options.pagination?.defaultPageSize);
   }
 
-  async listResourceTemplates(cursor?: string) {
-    return this.executor.listResourceTemplates(cursor);
+  async listResourceTemplates(cursor?: string, auth?: ListAuthContext) {
+    if (!this.options.filterListsByScopes) {
+      return this.executor.listResourceTemplates(cursor);
+    }
+    // Mirrors McpExecutorService.listResourceTemplates with scope filtering.
+    const entries = this.registry
+      .getAllResourceTemplates()
+      .filter((t) => this.hasRequiredScopes(requiredScopesOf(t), auth?.scopes))
+      .map((t) => ({
+        uriTemplate: t.uriTemplate,
+        name: t.name,
+        ...(t.title != null ? { title: t.title } : {}),
+        ...(t.description ? { description: t.description } : {}),
+        ...(t.mimeType ? { mimeType: t.mimeType } : {}),
+        ...(t.icons ? { icons: t.icons } : {}),
+        ...(t._meta ? { _meta: t._meta } : {}),
+      }));
+    return paginate(entries, cursor, this.options.pagination?.defaultPageSize);
   }
 
-  async listPrompts(cursor?: string) {
-    return this.executor.listPrompts(cursor);
+  async listPrompts(cursor?: string, auth?: ListAuthContext) {
+    if (!this.options.filterListsByScopes) {
+      return this.executor.listPrompts(cursor);
+    }
+    // Mirrors McpExecutorService.listPrompts with scope filtering.
+    const entries = this.registry
+      .getAllPrompts()
+      .filter((p) => this.hasRequiredScopes(requiredScopesOf(p), auth?.scopes))
+      .map((p) => ({
+        name: p.name,
+        ...(p.title != null ? { title: p.title } : {}),
+        description: p.description,
+        ...(p.parameters
+          ? {
+              arguments: extractZodDescriptions(p.parameters).map((arg) => ({
+                name: arg.name,
+                description: arg.description,
+                required: arg.required,
+              })),
+            }
+          : {}),
+        ...(p.icons ? { icons: p.icons } : {}),
+        ...(p._meta ? { _meta: p._meta } : {}),
+      }));
+    return paginate(entries, cursor, this.options.pagination?.defaultPageSize);
   }
 
   // ---- Completions ----
@@ -238,7 +317,7 @@ export class ExecutionPipelineService {
     const guardContext = this.buildGuardContext(ctx, extra);
 
     for (const GuardClass of this.options.guards) {
-      const guard = this.resolveGuard(GuardClass);
+      const guard = resolveGuard(this.moduleRef, GuardClass);
 
       if (typeof guard.canActivate === 'function') {
         await guard.canActivate(guardContext);
@@ -251,13 +330,18 @@ export class ExecutionPipelineService {
     }
   }
 
-  private resolveGuard(GuardClass: McpGuardClass): McpGuard {
-    try {
-      return this.moduleRef.get(GuardClass, { strict: false });
-    } catch {
-      // Guard not in DI — instantiate directly (for simple guards)
-      return new (GuardClass as new () => McpGuard)();
-    }
+  /**
+   * True when the caller's granted scopes cover the item's required scopes.
+   * Items without required scopes are visible to everyone, including
+   * unauthenticated callers.
+   */
+  private hasRequiredScopes(
+    requiredScopes: string[] | undefined,
+    grantedScopes: string[] | undefined,
+  ): boolean {
+    if (!requiredScopes?.length) return true;
+    const granted = grantedScopes ?? [];
+    return requiredScopes.every((scope) => granted.includes(scope));
   }
 
   private buildExecutionChain(
@@ -319,6 +403,7 @@ export class ExecutionPipelineService {
       user: ctx.user,
       metadata: ctx.metadata,
       request: ctx.request,
+      authInfo: ctx.authInfo,
       ...extra,
     };
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -41,6 +41,7 @@ export { McpExecutorService } from './execution/executor.service';
 export { ExecutionPipelineService } from './execution/pipeline.service';
 export { McpContextFactory } from './execution/context.factory';
 export { McpRequestContextService } from './execution/request-context.service';
+export { resolveGuard } from './utils/resolve-guard.util';
 
 // Transport
 export { StreamableHttpService } from './transport/streamable-http/streamable.service';
@@ -73,8 +74,11 @@ export {
   type BearerTokenVerifier,
 } from './auth/services/bearer-verifier.service';
 export { MemoryOAuthStore } from './auth/stores/memory-store.service';
-export type { IOAuthStore } from './auth/stores/oauth-store.interface';
-export type { McpAuthModuleOptions } from './auth/interfaces/auth-module-options.interface';
+export type { IOAuthStore, IssuedTokenRecord } from './auth/stores/oauth-store.interface';
+export type {
+  McpAuthModuleAsyncOptions,
+  McpAuthModuleOptions,
+} from './auth/interfaces/auth-module-options.interface';
 export type {
   OAuthProviderAdapter,
   OAuthProviderUser,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -67,6 +67,11 @@ export { AuthAuditService } from './auth/services/auth-audit.service';
 export type { AuditLogEntry } from './auth/services/auth-audit.service';
 export { JwtTokenService, MCP_AUTH_OPTIONS } from './auth/services/jwt-token.service';
 export { OAuthClientService, MCP_OAUTH_STORE } from './auth/services/client.service';
+export {
+  JwtBearerTokenVerifier,
+  MCP_BEARER_TOKEN_VERIFIER,
+  type BearerTokenVerifier,
+} from './auth/services/bearer-verifier.service';
 export { MemoryOAuthStore } from './auth/stores/memory-store.service';
 export type { IOAuthStore } from './auth/stores/oauth-store.interface';
 export type { McpAuthModuleOptions } from './auth/interfaces/auth-module-options.interface';

--- a/packages/server/src/mcp.module.spec.ts
+++ b/packages/server/src/mcp.module.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { McpTransportType } from '@nest-mcp/common';
 import { describe, expect, it } from 'vitest';
 import { McpModule } from './mcp.module';
@@ -44,6 +45,38 @@ describe('McpModule', () => {
         (p: Record<string, unknown>) => p.name ?? p.provide?.toString?.() ?? '',
       );
       expect(providerNames).toContain('StdioService');
+    });
+
+    it('applies controllerGuards to the streamable HTTP controller', () => {
+      class EdgeGuard {
+        canActivate(): boolean {
+          return true;
+        }
+      }
+      const mod = McpModule.forRoot({
+        name: 'test',
+        version: '1.0',
+        transport: McpTransportType.STREAMABLE_HTTP,
+        transportOptions: { streamableHttp: { controllerGuards: [EdgeGuard] } },
+      });
+
+      const [controller] = mod.controllers ?? [];
+      expect(Reflect.getMetadata('__guards__', controller)).toEqual([EdgeGuard]);
+    });
+
+    it('applies controllerDecorators to the streamable HTTP controller', () => {
+      const tag: ClassDecorator = (target) => {
+        Reflect.defineMetadata('custom:tag', 'from-forRoot', target);
+      };
+      const mod = McpModule.forRoot({
+        name: 'test',
+        version: '1.0',
+        transport: McpTransportType.STREAMABLE_HTTP,
+        transportOptions: { streamableHttp: { controllerDecorators: [tag] } },
+      });
+
+      const [controller] = mod.controllers ?? [];
+      expect(Reflect.getMetadata('custom:tag', controller)).toBe('from-forRoot');
     });
   });
 
@@ -130,6 +163,32 @@ describe('McpModule', () => {
       });
 
       expect(mod.controllers).toHaveLength(1);
+    });
+
+    it('applies static controllerGuards and controllerDecorators to the streamable HTTP controller', () => {
+      class EdgeGuard {
+        canActivate(): boolean {
+          return true;
+        }
+      }
+      const tag: ClassDecorator = (target) => {
+        Reflect.defineMetadata('custom:tag', 'from-forRootAsync', target);
+      };
+      const mod = McpModule.forRootAsync({
+        transport: McpTransportType.STREAMABLE_HTTP,
+        transportOptions: {
+          streamableHttp: { controllerGuards: [EdgeGuard], controllerDecorators: [tag] },
+        },
+        useFactory: () => ({
+          name: 'test',
+          version: '1.0',
+          transport: McpTransportType.STREAMABLE_HTTP,
+        }),
+      });
+
+      const [controller] = mod.controllers ?? [];
+      expect(Reflect.getMetadata('__guards__', controller)).toEqual([EdgeGuard]);
+      expect(Reflect.getMetadata('custom:tag', controller)).toBe('from-forRootAsync');
     });
 
     it('passes through imports from async options', () => {

--- a/packages/server/src/mcp.module.ts
+++ b/packages/server/src/mcp.module.ts
@@ -120,9 +120,15 @@ export class McpModule {
 
     // Streamable HTTP transport
     if (transports.includes(McpTransportType.STREAMABLE_HTTP)) {
-      const endpoint = options.transportOptions?.streamableHttp?.endpoint ?? DEFAULT_MCP_ENDPOINT;
+      const streamableHttp = options.transportOptions?.streamableHttp;
+      const endpoint = streamableHttp?.endpoint ?? DEFAULT_MCP_ENDPOINT;
       providers.push(StreamableHttpService);
-      controllers.push(createStreamableHttpController(endpoint));
+      controllers.push(
+        createStreamableHttpController(endpoint, {
+          guards: streamableHttp?.controllerGuards,
+          decorators: streamableHttp?.controllerDecorators,
+        }),
+      );
     }
 
     // SSE transport
@@ -194,11 +200,21 @@ export class McpModule {
 
     const transports = normalizeTransports(options.transport);
 
-    // Streamable HTTP transport
+    // Streamable HTTP transport.
+    // NOTE: controller shape (endpoint, controllerGuards, controllerDecorators)
+    // is read from the STATIC `transportOptions` on the async options object —
+    // controllers are created at module-definition time, before the factory
+    // runs. Runtime options resolved by `useFactory` flow through MCP_OPTIONS.
     if (transports.includes(McpTransportType.STREAMABLE_HTTP)) {
-      const endpoint = options.transportOptions?.streamableHttp?.endpoint ?? DEFAULT_MCP_ENDPOINT;
+      const streamableHttp = options.transportOptions?.streamableHttp;
+      const endpoint = streamableHttp?.endpoint ?? DEFAULT_MCP_ENDPOINT;
       providers.push(StreamableHttpService);
-      controllers.push(createStreamableHttpController(endpoint));
+      controllers.push(
+        createStreamableHttpController(endpoint, {
+          guards: streamableHttp?.controllerGuards,
+          decorators: streamableHttp?.controllerDecorators,
+        }),
+      );
     }
 
     // SSE transport

--- a/packages/server/src/transport/http-response.interface.ts
+++ b/packages/server/src/transport/http-response.interface.ts
@@ -3,4 +3,8 @@ export interface HttpResponse {
   json?: (body: unknown) => void;
   code?: (code: number) => HttpResponse;
   send?: (body: unknown) => void;
+  /** Express / Node `ServerResponse` header setter. */
+  setHeader?: (name: string, value: string) => unknown;
+  /** Fastify reply header setter. */
+  header?: (name: string, value: string) => unknown;
 }

--- a/packages/server/src/transport/register-handlers.spec.ts
+++ b/packages/server/src/transport/register-handlers.spec.ts
@@ -449,6 +449,7 @@ describe('registerHandlers', () => {
     expect(mockPipeline.listTools).toHaveBeenCalledWith(
       'abc123',
       expect.objectContaining({ transport: ctx.transport }),
+      { scopes: undefined },
     );
     expect(result).toEqual({ tools: [{ name: 'tool-a' }], nextCursor: 'abc123' });
   });
@@ -489,7 +490,7 @@ describe('registerHandlers', () => {
     const handler = listResourcesCall?.[1];
     const result = await handler({ method: 'resources/list', params: { cursor: 'next' } });
 
-    expect(mockPipeline.listResources).toHaveBeenCalledWith('next');
+    expect(mockPipeline.listResources).toHaveBeenCalledWith('next', { scopes: undefined });
     expect(result).toEqual({ resources: [{ uri: 'file:///a' }], nextCursor: 'next' });
   });
 
@@ -509,8 +510,79 @@ describe('registerHandlers', () => {
     const handler = listPromptsCall?.[1];
     const result = await handler({ method: 'prompts/list', params: {} });
 
-    expect(mockPipeline.listPrompts).toHaveBeenCalledWith(undefined);
+    expect(mockPipeline.listPrompts).toHaveBeenCalledWith(undefined, { scopes: undefined });
     expect(result).toEqual({ prompts: [{ name: 'greet' }] });
+  });
+
+  // --- Per-request extra on list handlers ---
+
+  function findListHandler(method: string) {
+    const call = mockInnerServer.setRequestHandler.mock.calls.find(
+      (c: unknown[]) =>
+        (c[0] as { shape?: { method?: { value?: string } } })?.shape?.method?.value === method,
+    );
+    return call?.[1];
+  }
+
+  it('list tools handler builds client context from extra.requestInfo and passes scopes', async () => {
+    registerHandlers(mockServer, mockRegistry, mockPipeline, ctx, mockOptions);
+
+    const handler = findListHandler('tools/list');
+    await handler(
+      { method: 'tools/list', params: {} },
+      {
+        authInfo: { scopes: ['tools:read'] },
+        requestInfo: { headers: { 'anthropic-beta': 'feature-x' } },
+      },
+    );
+
+    expect(mockPipeline.listTools).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ transport: ctx.transport, betaHeaders: ['feature-x'] }),
+      { scopes: ['tools:read'] },
+    );
+  });
+
+  it('list resources handler passes caller scopes from extra.authInfo', async () => {
+    registerHandlers(mockServer, mockRegistry, mockPipeline, ctx, mockOptions);
+
+    const handler = findListHandler('resources/list');
+    await handler(
+      { method: 'resources/list', params: {} },
+      { authInfo: { scopes: ['resources:read'] } },
+    );
+
+    expect(mockPipeline.listResources).toHaveBeenCalledWith(undefined, {
+      scopes: ['resources:read'],
+    });
+  });
+
+  it('list resource templates handler passes caller scopes from extra.authInfo', async () => {
+    registerHandlers(mockServer, mockRegistry, mockPipeline, ctx, mockOptions);
+
+    const handler = findListHandler('resources/templates/list');
+    await handler(
+      { method: 'resources/templates/list', params: { cursor: 'cur' } },
+      { authInfo: { scopes: ['templates:read'] } },
+    );
+
+    expect(mockPipeline.listResourceTemplates).toHaveBeenCalledWith('cur', {
+      scopes: ['templates:read'],
+    });
+  });
+
+  it('list prompts handler passes caller scopes from extra.authInfo', async () => {
+    registerHandlers(mockServer, mockRegistry, mockPipeline, ctx, mockOptions);
+
+    const handler = findListHandler('prompts/list');
+    await handler(
+      { method: 'prompts/list', params: {} },
+      { authInfo: { scopes: ['prompts:read'] } },
+    );
+
+    expect(mockPipeline.listPrompts).toHaveBeenCalledWith(undefined, {
+      scopes: ['prompts:read'],
+    });
   });
 
   // --- Completion ---
@@ -1113,6 +1185,78 @@ describe('registerToolOnServer', () => {
     await passedCtx.elicit(elicitParams as never, { signal: undefined });
     expect(elicitInput).toHaveBeenCalledWith(elicitParams, { signal: undefined });
   });
+
+  // --- Per-request auth context (stale-ctx fix) ---
+
+  it('tool callback overrides ctx.request/user/authInfo from extra', async () => {
+    ctx.request = { headers: { authorization: 'Bearer stale-init-token' } };
+    ctx.user = { id: 'stale-user' };
+    const tool = { name: 'secure', description: 'Secure', parameters: null };
+    registerToolOnServer(mockServer as never, tool as never, mockPipeline as never, ctx);
+
+    const callback = (mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    const authInfo = {
+      token: 'fresh-token',
+      clientId: 'client-1',
+      scopes: ['tools:read'],
+      extra: { sub: 'user-9' },
+    };
+    const requestInfo = { headers: { authorization: 'Bearer fresh-token' } };
+    await callback(
+      {},
+      { signal: new AbortController().signal, requestId: 'req-auth-1', authInfo, requestInfo },
+    );
+
+    const passedCtx = mockPipeline.callTool.mock.calls[0][2] as McpExecutionContext;
+    expect(passedCtx.authInfo).toBe(authInfo);
+    expect(passedCtx.request).toBe(requestInfo);
+    expect(passedCtx.user).toEqual({ id: 'user-9', scopes: ['tools:read'] });
+  });
+
+  it('tool callback falls back to clientId when authInfo has no sub', async () => {
+    const tool = { name: 'secure', description: 'Secure', parameters: null };
+    registerToolOnServer(mockServer as never, tool as never, mockPipeline as never, ctx);
+
+    const callback = (mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    const authInfo = { token: 't', clientId: 'client-2', scopes: [] };
+    await callback({}, { signal: new AbortController().signal, requestId: 'req-auth-2', authInfo });
+
+    const passedCtx = mockPipeline.callTool.mock.calls[0][2] as McpExecutionContext;
+    expect(passedCtx.user).toEqual({ id: 'client-2', scopes: [] });
+  });
+
+  it('tool callback keeps session user when extra has only requestInfo', async () => {
+    ctx.user = { id: 'session-user' };
+    const tool = { name: 'open', description: 'Open', parameters: null };
+    registerToolOnServer(mockServer as never, tool as never, mockPipeline as never, ctx);
+
+    const callback = (mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    const requestInfo = { headers: { 'x-trace': 'abc' } };
+    await callback(
+      {},
+      { signal: new AbortController().signal, requestId: 'req-auth-3', requestInfo },
+    );
+
+    const passedCtx = mockPipeline.callTool.mock.calls[0][2] as McpExecutionContext;
+    expect(passedCtx.request).toBe(requestInfo);
+    expect(passedCtx.user).toBe(ctx.user);
+    expect(passedCtx.authInfo).toBeUndefined();
+  });
+
+  it('tool callback passes session context through unchanged when extra has no auth', async () => {
+    ctx.request = { headers: { authorization: 'Bearer session' } };
+    ctx.user = { id: 'session-user' };
+    const tool = { name: 'plain', description: 'Plain', parameters: null };
+    registerToolOnServer(mockServer as never, tool as never, mockPipeline as never, ctx);
+
+    const callback = (mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    await callback({}, { signal: new AbortController().signal, requestId: 'req-auth-4' });
+
+    const passedCtx = mockPipeline.callTool.mock.calls[0][2] as McpExecutionContext;
+    expect(passedCtx.request).toBe(ctx.request);
+    expect(passedCtx.user).toBe(ctx.user);
+    expect(passedCtx.authInfo).toBeUndefined();
+  });
 });
 
 describe('registerResourceOnServer', () => {
@@ -1157,6 +1301,42 @@ describe('registerResourceOnServer', () => {
     const resourceFn = mockServer.resource as ReturnType<typeof vi.fn>;
     const [, , metadata] = resourceFn.mock.calls[0];
     expect(metadata).toEqual({ mimeType: 'application/json' });
+  });
+
+  it('resource callback applies per-request auth from extra', async () => {
+    const resource = { name: 'secure', uri: 'data://secure', mimeType: undefined };
+    registerResourceOnServer(mockServer as never, resource as never, mockPipeline as never, ctx);
+
+    const callback = (mockServer.resource as ReturnType<typeof vi.fn>).mock.calls[0][3];
+    const authInfo = { token: 't', clientId: 'client-1', scopes: ['r'], extra: { sub: 'user-1' } };
+    const requestInfo = { headers: { authorization: 'Bearer t' } };
+    await callback(new URL('data://secure'), {
+      signal: new AbortController().signal,
+      requestId: 'req-r-auth',
+      authInfo,
+      requestInfo,
+    });
+
+    const passedCtx = mockPipeline.readResource.mock.calls[0][1] as McpExecutionContext;
+    expect(passedCtx.authInfo).toBe(authInfo);
+    expect(passedCtx.request).toBe(requestInfo);
+    expect(passedCtx.user).toEqual({ id: 'user-1', scopes: ['r'] });
+  });
+
+  it('resource callback passes context through unchanged when extra has no auth', async () => {
+    ctx.user = { id: 'session-user' };
+    const resource = { name: 'plain', uri: 'data://plain', mimeType: undefined };
+    registerResourceOnServer(mockServer as never, resource as never, mockPipeline as never, ctx);
+
+    const callback = (mockServer.resource as ReturnType<typeof vi.fn>).mock.calls[0][3];
+    await callback(new URL('data://plain'), {
+      signal: new AbortController().signal,
+      requestId: 'req-r-plain',
+    });
+
+    const passedCtx = mockPipeline.readResource.mock.calls[0][1] as McpExecutionContext;
+    expect(passedCtx.user).toBe(ctx.user);
+    expect(passedCtx.authInfo).toBeUndefined();
   });
 });
 
@@ -1221,6 +1401,30 @@ describe('registerResourceTemplateOnServer', () => {
     expect(passedCtx.signal).toBeDefined();
     expect(passedCtx.signal?.aborted).toBe(false);
   });
+
+  it('resource template callback applies per-request auth from extra', async () => {
+    const template = { name: 'user', uriTemplate: 'data://users/{id}', mimeType: undefined };
+    registerResourceTemplateOnServer(
+      mockServer as never,
+      template as never,
+      mockPipeline as never,
+      ctx,
+    );
+
+    const callback = (mockServer.registerResource as ReturnType<typeof vi.fn>).mock.calls[0][3];
+    const authInfo = { token: 't', clientId: 'client-1', scopes: ['r'], extra: { sub: 'user-2' } };
+    const requestInfo = { headers: { authorization: 'Bearer t' } };
+    await callback(
+      new URL('data://users/1'),
+      {},
+      { signal: new AbortController().signal, requestId: 'req-t-auth', authInfo, requestInfo },
+    );
+
+    const passedCtx = mockPipeline.readResource.mock.calls[0][1] as McpExecutionContext;
+    expect(passedCtx.authInfo).toBe(authInfo);
+    expect(passedCtx.request).toBe(requestInfo);
+    expect(passedCtx.user).toEqual({ id: 'user-2', scopes: ['r'] });
+  });
 });
 
 describe('registerPromptOnServer', () => {
@@ -1268,5 +1472,36 @@ describe('registerPromptOnServer', () => {
     expect(name).toBe('greet');
     expect(config.description).toBe('Greet');
     expect(config.argsSchema).toBe(schema.shape);
+  });
+
+  it('prompt callback applies per-request auth from extra', async () => {
+    const prompt = { name: 'secure', description: 'Secure', parameters: null };
+    registerPromptOnServer(mockServer as never, prompt as never, mockPipeline as never, ctx);
+
+    const callback = (mockServer.registerPrompt as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    const authInfo = { token: 't', clientId: 'client-1', scopes: ['p'], extra: { sub: 'user-3' } };
+    const requestInfo = { headers: { authorization: 'Bearer t' } };
+    await callback(
+      {},
+      { signal: new AbortController().signal, requestId: 'req-p-auth', authInfo, requestInfo },
+    );
+
+    const passedCtx = mockPipeline.getPrompt.mock.calls[0][2] as McpExecutionContext;
+    expect(passedCtx.authInfo).toBe(authInfo);
+    expect(passedCtx.request).toBe(requestInfo);
+    expect(passedCtx.user).toEqual({ id: 'user-3', scopes: ['p'] });
+  });
+
+  it('prompt callback passes context through unchanged when extra has no auth', async () => {
+    ctx.user = { id: 'session-user' };
+    const prompt = { name: 'plain', description: 'Plain', parameters: null };
+    registerPromptOnServer(mockServer as never, prompt as never, mockPipeline as never, ctx);
+
+    const callback = (mockServer.registerPrompt as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    await callback({}, { signal: new AbortController().signal, requestId: 'req-p-plain' });
+
+    const passedCtx = mockPipeline.getPrompt.mock.calls[0][2] as McpExecutionContext;
+    expect(passedCtx.user).toBe(ctx.user);
+    expect(passedCtx.authInfo).toBeUndefined();
   });
 });

--- a/packages/server/src/transport/register-handlers.ts
+++ b/packages/server/src/transport/register-handlers.ts
@@ -17,6 +17,7 @@ import {
 import type {
   ElicitRequest,
   ElicitResult,
+  McpAuthInfo,
   McpExecutionContext,
   McpModuleOptions,
   McpProgress,
@@ -48,6 +49,41 @@ const PASSTHROUGH_SCHEMA = z.looseObject({});
  * notification is received from the client.
  */
 const activeRequests = new Map<string | number, AbortController>();
+
+/** Headers of the originating HTTP request, as surfaced by the SDK transport. */
+interface RequestInfoLike {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Per-request auth/request surface of the SDK `RequestHandlerExtra`
+ * (structural — `@nest-mcp/common` stays SDK-free). `authInfo` carries the
+ * identity the HTTP edge attached to `req.auth`; `requestInfo` carries the
+ * headers of the HTTP request that delivered this JSON-RPC message.
+ */
+interface RequestAuthExtra {
+  authInfo?: McpAuthInfo;
+  requestInfo?: RequestInfoLike;
+}
+
+/**
+ * Builds a fresh per-request execution context from the SDK's per-request
+ * `extra`. The session-level `ctx` captured at connect time would otherwise
+ * go stale: on stateful transports every subsequent request reuses the
+ * initialize-request's headers/identity. When the transport provides neither
+ * `authInfo` nor `requestInfo` (SSE, STDIO), the context passes through
+ * unchanged.
+ */
+function withRequestAuth(ctx: McpExecutionContext, extra: RequestAuthExtra): McpExecutionContext {
+  if (!extra.authInfo && !extra.requestInfo) return ctx;
+  const user = extra.authInfo
+    ? {
+        id: (extra.authInfo.extra?.sub as string) ?? extra.authInfo.clientId,
+        scopes: extra.authInfo.scopes,
+      }
+    : ctx.user;
+  return { ...ctx, request: extra.requestInfo ?? ctx.request, authInfo: extra.authInfo, user };
+}
 
 function createSignalContext(
   ctx: McpExecutionContext,
@@ -144,7 +180,7 @@ export function registerToolOnServer(
     },
     async (
       args: Record<string, unknown>,
-      extra: {
+      extra: RequestAuthExtra & {
         signal: AbortSignal;
         requestId: string | number;
         _meta?: { progressToken?: string | number };
@@ -154,7 +190,10 @@ export function registerToolOnServer(
         }) => Promise<void>;
       },
     ) => {
-      const { ctxWithSignal: baseCtxWithSignal, cleanup } = createSignalContext(ctx, extra);
+      // Fresh spread per call: the pipeline's user write-back stays
+      // request-isolated instead of mutating the shared session context.
+      const requestCtx = withRequestAuth(ctx, extra);
+      const { ctxWithSignal: baseCtxWithSignal, cleanup } = createSignalContext(requestCtx, extra);
 
       // Build per-request reportProgress that sends notifications/progress
       // when the client provided a progressToken in _meta
@@ -228,8 +267,11 @@ export function registerResourceOnServer(
     resource.name,
     resource.uri,
     resource.mimeType ? { mimeType: resource.mimeType } : {},
-    async (uri: URL, extra: { signal: AbortSignal; requestId: string | number }) => {
-      const { ctxWithSignal, cleanup } = createSignalContext(ctx, extra);
+    async (
+      uri: URL,
+      extra: RequestAuthExtra & { signal: AbortSignal; requestId: string | number },
+    ) => {
+      const { ctxWithSignal, cleanup } = createSignalContext(withRequestAuth(ctx, extra), extra);
       try {
         return await pipeline.readResource(uri.href, ctxWithSignal);
       } finally {
@@ -261,9 +303,9 @@ export function registerResourceTemplateOnServer(
     async (
       uri: URL,
       _variables: Record<string, string>,
-      extra: { signal: AbortSignal; requestId: string | number },
+      extra: RequestAuthExtra & { signal: AbortSignal; requestId: string | number },
     ) => {
-      const { ctxWithSignal, cleanup } = createSignalContext(ctx, extra);
+      const { ctxWithSignal, cleanup } = createSignalContext(withRequestAuth(ctx, extra), extra);
       try {
         return await pipeline.readResource(uri.href, ctxWithSignal);
       } finally {
@@ -295,9 +337,9 @@ export function registerPromptOnServer(
     },
     async (
       args: Record<string, unknown>,
-      extra: { signal: AbortSignal; requestId: string | number },
+      extra: RequestAuthExtra & { signal: AbortSignal; requestId: string | number },
     ) => {
-      const { ctxWithSignal, cleanup } = createSignalContext(ctx, extra);
+      const { ctxWithSignal, cleanup } = createSignalContext(withRequestAuth(ctx, extra), extra);
       try {
         return await pipeline.getPrompt(prompt.name, args, ctxWithSignal);
       } finally {
@@ -325,6 +367,16 @@ function registerCancellationHandler(server: McpServer): void {
 }
 
 /**
+ * Loose per-request view of the SDK `RequestHandlerExtra` for typed
+ * `setRequestHandler` callbacks. Wider than {@link RequestAuthExtra} so the
+ * SDK's concrete `AuthInfo` (whose `resource` is a `URL`) stays assignable.
+ */
+interface ListHandlerExtra {
+  authInfo?: { scopes?: string[] };
+  requestInfo?: RequestInfoLike;
+}
+
+/**
  * Registers custom list request handlers on the low-level SDK Server to
  * support cursor-based pagination. These override the SDK's default
  * list handlers that were auto-registered by registerTool/resource/prompt.
@@ -339,50 +391,69 @@ function registerListHandlers(
   options: McpModuleOptions,
   ctx: McpExecutionContext,
 ): void {
-  server.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-    const cursor = request.params?.cursor;
-    const clientContext = buildClientContext({
-      transport: ctx.transport,
-      request: ctx.request,
-    });
-    const result = await pipeline.listTools(cursor, clientContext);
-    return { tools: result.items, ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}) };
-  });
+  server.server.setRequestHandler(
+    ListToolsRequestSchema,
+    async (request, extra?: ListHandlerExtra) => {
+      const cursor = request.params?.cursor;
+      const clientContext = buildClientContext({
+        transport: ctx.transport,
+        request: extra?.requestInfo ?? ctx.request,
+      });
+      const result = await pipeline.listTools(cursor, clientContext, {
+        scopes: extra?.authInfo?.scopes,
+      });
+      return {
+        tools: result.items,
+        ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+      };
+    },
+  );
 
   const hasResources =
     registry.hasResources || registry.hasResourceTemplates || !!options.capabilities?.resources;
 
   if (hasResources) {
-    server.server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
-      const cursor = request.params?.cursor;
-      const result = await pipeline.listResources(cursor);
-      return {
-        resources: result.items,
-        ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
-      };
-    });
+    server.server.setRequestHandler(
+      ListResourcesRequestSchema,
+      async (request, extra?: ListHandlerExtra) => {
+        const cursor = request.params?.cursor;
+        const result = await pipeline.listResources(cursor, { scopes: extra?.authInfo?.scopes });
+        return {
+          resources: result.items,
+          ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+        };
+      },
+    );
 
-    server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async (request) => {
-      const cursor = request.params?.cursor;
-      const result = await pipeline.listResourceTemplates(cursor);
-      return {
-        resourceTemplates: result.items,
-        ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
-      };
-    });
+    server.server.setRequestHandler(
+      ListResourceTemplatesRequestSchema,
+      async (request, extra?: ListHandlerExtra) => {
+        const cursor = request.params?.cursor;
+        const result = await pipeline.listResourceTemplates(cursor, {
+          scopes: extra?.authInfo?.scopes,
+        });
+        return {
+          resourceTemplates: result.items,
+          ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+        };
+      },
+    );
   }
 
   const hasPrompts = registry.hasPrompts || !!options.capabilities?.prompts;
 
   if (hasPrompts) {
-    server.server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
-      const cursor = request.params?.cursor;
-      const result = await pipeline.listPrompts(cursor);
-      return {
-        prompts: result.items,
-        ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
-      };
-    });
+    server.server.setRequestHandler(
+      ListPromptsRequestSchema,
+      async (request, extra?: ListHandlerExtra) => {
+        const cursor = request.params?.cursor;
+        const result = await pipeline.listPrompts(cursor, { scopes: extra?.authInfo?.scopes });
+        return {
+          prompts: result.items,
+          ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+        };
+      },
+    );
   }
 }
 

--- a/packages/server/src/transport/streamable-http/streamable.controller.factory.spec.ts
+++ b/packages/server/src/transport/streamable-http/streamable.controller.factory.spec.ts
@@ -105,4 +105,59 @@ describe('createStreamableHttpController', () => {
       expect(Reflect.getMetadata('path', CustomController)).toBe('/custom-mcp');
     });
   });
+
+  describe('guards and decorators', () => {
+    class FakeGuard {
+      canActivate(): boolean {
+        return true;
+      }
+    }
+
+    it('applies UseGuards metadata when guards are provided', () => {
+      const Guarded = createStreamableHttpController('/mcp', { guards: [FakeGuard] });
+      expect(Reflect.getMetadata('__guards__', Guarded)).toEqual([FakeGuard]);
+    });
+
+    it('applies no guard metadata when guards are omitted', () => {
+      const Plain = createStreamableHttpController('/mcp');
+      expect(Reflect.getMetadata('__guards__', Plain)).toBeUndefined();
+    });
+
+    it('applies no guard metadata when guards is an empty array', () => {
+      const Plain = createStreamableHttpController('/mcp', { guards: [] });
+      expect(Reflect.getMetadata('__guards__', Plain)).toBeUndefined();
+    });
+
+    it('applies each provided class decorator to the controller', () => {
+      const seen: unknown[] = [];
+      const tagDecorator: ClassDecorator = (target) => {
+        seen.push(target);
+        Reflect.defineMetadata('custom:tag', 'mcp', target);
+      };
+      const Decorated = createStreamableHttpController('/mcp', { decorators: [tagDecorator] });
+
+      expect(seen).toEqual([Decorated]);
+      expect(Reflect.getMetadata('custom:tag', Decorated)).toBe('mcp');
+    });
+
+    it('honors a decorator that replaces the class', () => {
+      const replaceDecorator = ((target: new (...args: unknown[]) => unknown) => {
+        return class Replaced extends target {};
+      }) as ClassDecorator;
+      const Replaced = createStreamableHttpController('/mcp', { decorators: [replaceDecorator] });
+
+      expect(Replaced.name).toBe('Replaced');
+      // Controller metadata is inherited through the prototype chain.
+      expect(Reflect.getMetadata('path', Replaced)).toBe('/mcp');
+    });
+
+    it('keeps guards applied alongside decorators', () => {
+      const noop: ClassDecorator = () => undefined;
+      const Combined = createStreamableHttpController('/mcp', {
+        guards: [FakeGuard],
+        decorators: [noop],
+      });
+      expect(Reflect.getMetadata('__guards__', Combined)).toEqual([FakeGuard]);
+    });
+  });
 });

--- a/packages/server/src/transport/streamable-http/streamable.controller.factory.ts
+++ b/packages/server/src/transport/streamable-http/streamable.controller.factory.ts
@@ -1,4 +1,5 @@
 import {
+  type CanActivate,
   Controller,
   Delete,
   Get,
@@ -6,11 +7,33 @@ import {
   Req,
   Res,
   type Type,
+  UseGuards,
   VERSION_NEUTRAL,
 } from '@nestjs/common';
 import { StreamableHttpService } from './streamable.service';
 
-export function createStreamableHttpController(endpoint: string): Type<unknown> {
+export interface StreamableHttpControllerOptions {
+  /**
+   * NestJS guards applied to the generated controller via `@UseGuards`.
+   * Accepts guard classes or instances, like `UseGuards` itself.
+   */
+  guards?: unknown[];
+  /** Class decorators applied to the generated controller (e.g. `@ApiTags`). */
+  decorators?: ClassDecorator[];
+}
+
+/**
+ * Builds the controller serving the streamable HTTP endpoint.
+ *
+ * The controller class (path, guards, decorators) is created when the module
+ * is defined, so this configuration must be static — even with
+ * `McpModule.forRootAsync`, where only the runtime options resolved by the
+ * factory flow through `MCP_OPTIONS`.
+ */
+export function createStreamableHttpController(
+  endpoint: string,
+  opts?: StreamableHttpControllerOptions,
+): Type<unknown> {
   @Controller({ path: endpoint, version: VERSION_NEUTRAL })
   class StreamableHttpController {
     constructor(private readonly streamableService: StreamableHttpService) {}
@@ -31,5 +54,17 @@ export function createStreamableHttpController(endpoint: string): Type<unknown> 
     }
   }
 
-  return StreamableHttpController;
+  if (opts?.guards?.length) {
+    UseGuards(...(opts.guards as (CanActivate | (new (...args: never[]) => CanActivate))[]))(
+      StreamableHttpController,
+    );
+  }
+
+  let controller: Type<unknown> = StreamableHttpController;
+  for (const decorator of opts?.decorators ?? []) {
+    // Honor decorator return values (a decorator may replace the class).
+    controller = (decorator(controller) as Type<unknown> | undefined) ?? controller;
+  }
+
+  return controller;
 }

--- a/packages/server/src/transport/streamable-http/streamable.oauth-gate.spec.ts
+++ b/packages/server/src/transport/streamable-http/streamable.oauth-gate.spec.ts
@@ -1,0 +1,234 @@
+import 'reflect-metadata';
+import type { McpModuleOptions } from '@nest-mcp/common';
+import { McpTransportType } from '@nest-mcp/common';
+import * as jwt from 'jsonwebtoken';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JwtBearerTokenVerifier } from '../../auth/services/bearer-verifier.service';
+import { JwtTokenService } from '../../auth/services/jwt-token.service';
+import { MemoryOAuthStore } from '../../auth/stores/memory-store.service';
+import { StreamableHttpService } from './streamable.service';
+
+// ---------------------------------------------------------------------------
+// Same SDK/module mocks as streamable.service.spec.ts — but the bearer
+// verification stack (JwtTokenService → JwtBearerTokenVerifier →
+// MemoryOAuthStore) is REAL, so this spec smoke-tests the oauth gate with
+// actually minted, revoked, and tampered JWTs instead of a mocked verifier.
+// ---------------------------------------------------------------------------
+
+const hoisted = vi.hoisted(() => ({
+  transports: [] as Array<{
+    sessionId: string | undefined;
+    handleRequest: (...args: unknown[]) => Promise<void>;
+    close: () => Promise<void>;
+  }>,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => {
+  class FakeStreamableTransport {
+    options: Record<string, unknown>;
+    sessionId: string | undefined;
+    onclose?: () => void;
+    handleRequest = vi.fn(async () => {
+      const generate = this.options.sessionIdGenerator as (() => string) | undefined;
+      if (generate && !this.sessionId) this.sessionId = generate();
+    });
+    close = vi.fn(async () => {});
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      hoisted.transports.push(this as never);
+    }
+  }
+  return { StreamableHTTPServerTransport: FakeStreamableTransport };
+});
+
+vi.mock('../../server/server.factory', () => ({
+  createMcpServer: vi.fn(() => ({
+    connect: vi.fn(),
+    close: vi.fn(async () => {}),
+    server: { notification: vi.fn().mockResolvedValue(undefined) },
+  })),
+}));
+
+vi.mock('../register-handlers', () => ({
+  registerHandlers: vi.fn(),
+  registerToolOnServer: vi.fn(() => ({ remove: vi.fn() })),
+  registerResourceOnServer: vi.fn(() => ({ remove: vi.fn() })),
+  registerResourceTemplateOnServer: vi.fn(() => ({ remove: vi.fn() })),
+  registerPromptOnServer: vi.fn(() => ({ remove: vi.fn() })),
+}));
+
+const JWT_SECRET = 'oauth-gate-smoke-secret-key-at-least-32-chars';
+
+function makeOptions(): McpModuleOptions {
+  return {
+    name: 'oauth-gate-smoke',
+    version: '1.0.0',
+    transport: McpTransportType.STREAMABLE_HTTP,
+    transportOptions: {
+      streamableHttp: {
+        sessionIdGenerator: () => 'sess-1',
+        oauth: { enabled: true },
+      },
+    },
+  };
+}
+
+function makeService() {
+  const jwtService = new JwtTokenService({ jwtSecret: JWT_SECRET });
+  const store = new MemoryOAuthStore();
+  const verifier = new JwtBearerTokenVerifier(jwtService, store);
+
+  const service = new StreamableHttpService(
+    makeOptions(),
+    { events: { on: vi.fn() } } as never,
+    {} as never,
+    {} as never,
+    {
+      createContext: vi.fn((args: Record<string, unknown>) => ({ ...args, metadata: {} })),
+    } as never,
+    { get: vi.fn(() => verifier) } as never,
+    undefined,
+    undefined,
+  );
+  return { service, jwtService, store };
+}
+
+interface ExpressRes {
+  headersSent: boolean;
+  statusCode?: number;
+  body?: unknown;
+  on: ReturnType<typeof vi.fn>;
+  setHeader: ReturnType<typeof vi.fn>;
+  status: (code: number) => { json: (body: unknown) => void; end: () => void };
+}
+
+function makeRes(): ExpressRes {
+  const res: ExpressRes = {
+    headersSent: false,
+    on: vi.fn(),
+    setHeader: vi.fn(),
+    status: (code: number) => {
+      res.statusCode = code;
+      return {
+        json: (body: unknown) => {
+          res.body = body;
+          res.headersSent = true;
+        },
+        end: () => {
+          res.headersSent = true;
+        },
+      };
+    },
+  };
+  return res;
+}
+
+function makeReq(headers: Record<string, string> = {}) {
+  return { headers: { host: 'api.example.com', ...headers } } as {
+    headers: Record<string, string>;
+    auth?: { clientId: string; scopes: string[]; extra?: Record<string, unknown> };
+  };
+}
+
+describe('streamable HTTP oauth gate with the real JWT verifier (smoke)', () => {
+  beforeEach(() => {
+    hoisted.transports.length = 0;
+  });
+
+  it('responds 401 with a WWW-Authenticate challenge when no bearer token is sent', async () => {
+    const { service } = makeService();
+    const res = makeRes();
+
+    await service.handlePostRequest(makeReq(), res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'WWW-Authenticate',
+      'Bearer realm="mcp", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"',
+    );
+    expect(res.body).toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Unauthorized' },
+      id: null,
+    });
+    expect(hoisted.transports).toHaveLength(0);
+  });
+
+  it('responds 401 for a token signed with the wrong secret', async () => {
+    const { service } = makeService();
+    const forged = jwt.sign({ sub: 'u', type: 'access' }, 'wrong-secret', { algorithm: 'HS256' });
+    const res = makeRes();
+
+    await service.handlePostRequest(makeReq({ authorization: `Bearer ${forged}` }), res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.setHeader).toHaveBeenCalledWith('WWW-Authenticate', expect.any(String));
+  });
+
+  it('admits a freshly minted access token and attaches the verified identity', async () => {
+    const { service, jwtService } = makeService();
+    const { access_token } = jwtService.generateTokenPair('user-1', 'client-1', 'tools:read');
+    const req = makeReq({ authorization: `Bearer ${access_token}` });
+    const res = makeRes();
+
+    await service.handlePostRequest(req, res);
+
+    expect(res.statusCode).toBeUndefined();
+    expect(req.auth).toMatchObject({
+      clientId: 'client-1',
+      scopes: ['tools:read'],
+      extra: { sub: 'user-1' },
+    });
+    expect(hoisted.transports).toHaveLength(1);
+    expect(hoisted.transports[0].handleRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a minted access token after its jti is revoked', async () => {
+    const { service, jwtService, store } = makeService();
+    const { access_token } = jwtService.generateTokenPair('user-1', 'client-1');
+    const { jti } = jwt.decode(access_token) as { jti: string };
+    await store.revokeToken(jti);
+    const res = makeRes();
+
+    await service.handlePostRequest(makeReq({ authorization: `Bearer ${access_token}` }), res);
+
+    expect(res.statusCode).toBe(401);
+    expect(hoisted.transports).toHaveLength(0);
+  });
+
+  it('rejects a refresh token presented as a bearer token', async () => {
+    const { service, jwtService } = makeService();
+    const { refresh_token } = jwtService.generateTokenPair('user-1', 'client-1');
+    const res = makeRes();
+
+    await service.handlePostRequest(makeReq({ authorization: `Bearer ${refresh_token}` }), res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('binds the session to the minted token principal and rejects another real principal', async () => {
+    const { service, jwtService } = makeService();
+    const owner = jwtService.generateTokenPair('user-1', 'client-1').access_token;
+    const intruder = jwtService.generateTokenPair('user-2', 'client-2').access_token;
+
+    // Initialize the session as user-1 (FakeStreamableTransport assigns sess-1).
+    await service.handlePostRequest(makeReq({ authorization: `Bearer ${owner}` }), makeRes());
+
+    const forbidden = makeRes();
+    await service.handlePostRequest(
+      makeReq({ authorization: `Bearer ${intruder}`, 'mcp-session-id': 'sess-1' }),
+      forbidden,
+    );
+    expect(forbidden.statusCode).toBe(403);
+    expect(forbidden.body).toEqual({ error: 'Session does not belong to this principal' });
+
+    const allowed = makeRes();
+    await service.handlePostRequest(
+      makeReq({ authorization: `Bearer ${owner}`, 'mcp-session-id': 'sess-1' }),
+      allowed,
+    );
+    expect(allowed.statusCode).toBeUndefined();
+    expect(hoisted.transports[0].handleRequest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/server/src/transport/streamable-http/streamable.service.spec.ts
+++ b/packages/server/src/transport/streamable-http/streamable.service.spec.ts
@@ -1,7 +1,69 @@
 import { EventEmitter } from 'node:events';
-import type { McpModuleOptions, StreamableHttpTransportOptions } from '@nest-mcp/common';
+import type {
+  McpAuthInfo,
+  McpModuleOptions,
+  StreamableHttpTransportOptions,
+} from '@nest-mcp/common';
 import { McpTransportType } from '@nest-mcp/common';
+import { Logger } from '@nestjs/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StreamableHttpService } from './streamable.service';
+
+// ---------------------------------------------------------------------------
+// Module mocks so the real StreamableHttpService can run without the SDK
+// ---------------------------------------------------------------------------
+interface FakeTransportInstance {
+  options: Record<string, unknown>;
+  sessionId: string | undefined;
+  onclose?: () => void;
+  handleRequest: (...args: unknown[]) => Promise<void>;
+  close: () => Promise<void>;
+}
+
+const hoisted = vi.hoisted(() => ({
+  transports: [] as Array<{
+    options: Record<string, unknown>;
+    sessionId: string | undefined;
+    onclose?: () => void;
+    handleRequest: (...args: unknown[]) => Promise<void>;
+    close: () => Promise<void>;
+  }>,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => {
+  class FakeStreamableTransport {
+    options: Record<string, unknown>;
+    sessionId: string | undefined;
+    onclose?: () => void;
+    handleRequest = vi.fn(async () => {
+      const generate = this.options.sessionIdGenerator as (() => string) | undefined;
+      if (generate && !this.sessionId) this.sessionId = generate();
+    });
+    close = vi.fn(async () => {});
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      hoisted.transports.push(this as never);
+    }
+  }
+  return { StreamableHTTPServerTransport: FakeStreamableTransport };
+});
+
+vi.mock('../../server/server.factory', () => ({
+  createMcpServer: vi.fn(() => ({
+    connect: vi.fn(),
+    close: vi.fn(async () => {}),
+    server: { notification: vi.fn().mockResolvedValue(undefined) },
+  })),
+}));
+
+vi.mock('../register-handlers', () => ({
+  registerHandlers: vi.fn(),
+  registerToolOnServer: vi.fn(() => ({ remove: vi.fn() })),
+  registerResourceOnServer: vi.fn(() => ({ remove: vi.fn() })),
+  registerResourceTemplateOnServer: vi.fn(() => ({ remove: vi.fn() })),
+  registerPromptOnServer: vi.fn(() => ({ remove: vi.fn() })),
+}));
 
 // ---------------------------------------------------------------------------
 // Mock register functions (stand-ins for register-handlers exports)
@@ -383,6 +445,9 @@ function buildTransportOptions(
     onsessioninitialized: opts?.onsessioninitialized,
     onsessionclosed: opts?.onsessionclosed,
     retryInterval: opts?.retryInterval,
+    allowedHosts: opts?.allowedHosts,
+    allowedOrigins: opts?.allowedOrigins,
+    enableDnsRebindingProtection: opts?.enableDnsRebindingProtection,
   };
 }
 
@@ -440,6 +505,20 @@ describe('buildTransportOptions logic', () => {
     expect(result.retryInterval).toBe(5000);
   });
 
+  it('passes DNS-rebinding protection options through', () => {
+    const result = buildTransportOptions(
+      makeOptions({
+        allowedHosts: ['localhost'],
+        allowedOrigins: ['https://app.example.com'],
+        enableDnsRebindingProtection: true,
+      }),
+      false,
+    );
+    expect(result.allowedHosts).toEqual(['localhost']);
+    expect(result.allowedOrigins).toEqual(['https://app.example.com']);
+    expect(result.enableDnsRebindingProtection).toBe(true);
+  });
+
   it('passes onsessioninitialized callback through', () => {
     const cb = vi.fn();
     const result = buildTransportOptions(makeOptions({ onsessioninitialized: cb }), false);
@@ -488,5 +567,426 @@ describe('buildTransportOptions logic', () => {
     expect(result.onsessioninitialized).toBe(onInit);
     expect(result.onsessionclosed).toBe(onClose);
     expect(result.retryInterval).toBe(3000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP edge auth (oauth gate) + session-identity binding
+// ---------------------------------------------------------------------------
+
+function makeServiceOptions(streamableHttp?: StreamableHttpTransportOptions): McpModuleOptions {
+  return {
+    name: 'test-server',
+    version: '1.0.0',
+    transport: McpTransportType.STREAMABLE_HTTP,
+    transportOptions: {
+      streamableHttp: { sessionIdGenerator: () => 'sess-1', ...streamableHttp },
+    },
+  };
+}
+
+function makeService(options: McpModuleOptions, verifier?: { verify: ReturnType<typeof vi.fn> }) {
+  const registry = { events: new EventEmitter() };
+  const moduleRef = {
+    get: vi.fn(() => {
+      if (!verifier) throw new Error('MCP_BEARER_TOKEN_VERIFIER is not registered');
+      return verifier;
+    }),
+  };
+  const contextFactory = {
+    createContext: vi.fn((args: Record<string, unknown>) => ({ ...args, metadata: {} })),
+  };
+
+  const service = new StreamableHttpService(
+    options,
+    registry as never,
+    {} as never,
+    {} as never,
+    contextFactory as never,
+    moduleRef as never,
+    undefined,
+    undefined,
+  );
+  return { service, moduleRef };
+}
+
+interface RecordedResponse {
+  headersSent: boolean;
+  statusCode?: number;
+  body?: unknown;
+  on: ReturnType<typeof vi.fn>;
+}
+
+function makeExpressRes() {
+  const res: RecordedResponse & {
+    setHeader: ReturnType<typeof vi.fn>;
+    status: (code: number) => { json: (body: unknown) => void; end: () => void };
+  } = {
+    headersSent: false,
+    on: vi.fn(),
+    setHeader: vi.fn(),
+    status: (code: number) => {
+      res.statusCode = code;
+      return {
+        json: (body: unknown) => {
+          res.body = body;
+          res.headersSent = true;
+        },
+        end: () => {
+          res.headersSent = true;
+        },
+      };
+    },
+  };
+  return res;
+}
+
+function makeFastifyRes() {
+  const res: RecordedResponse & {
+    header: ReturnType<typeof vi.fn>;
+    code: (code: number) => { send: (body?: unknown) => void };
+  } = {
+    headersSent: false,
+    on: vi.fn(),
+    header: vi.fn(),
+    code: (code: number) => {
+      res.statusCode = code;
+      return {
+        send: (body?: unknown) => {
+          res.body = body;
+          res.headersSent = true;
+        },
+      };
+    },
+  };
+  return res;
+}
+
+function makeReq(headers: Record<string, string> = {}): {
+  headers: Record<string, string>;
+  auth?: McpAuthInfo;
+} {
+  return { headers: { host: 'api.example.com', ...headers } };
+}
+
+function makeAuthInfo(sub: string, clientId = 'client-1'): McpAuthInfo {
+  return { token: `token-${sub}`, clientId, scopes: ['read'], extra: { sub } };
+}
+
+function lastTransport(): FakeTransportInstance {
+  const transport = hoisted.transports.at(-1);
+  if (!transport) throw new Error('no transport was created');
+  return transport;
+}
+
+describe('StreamableHttpService oauth edge auth', () => {
+  beforeEach(() => {
+    hoisted.transports.length = 0;
+  });
+
+  it('responds 401 with the path-inserted WWW-Authenticate default (Express shim)', async () => {
+    const verifier = { verify: vi.fn() };
+    const { service } = makeService(makeServiceOptions({ oauth: { enabled: true } }), verifier);
+    const res = makeExpressRes();
+
+    await service.handlePostRequest(makeReq(), res);
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'WWW-Authenticate',
+      'Bearer realm="mcp", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"',
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Unauthorized' },
+      id: null,
+    });
+    expect(verifier.verify).not.toHaveBeenCalled();
+    expect(hoisted.transports).toHaveLength(0);
+  });
+
+  it('responds 401 via the Fastify shim (header + code().send())', async () => {
+    const verifier = { verify: vi.fn().mockResolvedValue(null) };
+    const { service } = makeService(makeServiceOptions({ oauth: { enabled: true } }), verifier);
+    const res = makeFastifyRes();
+
+    await service.handlePostRequest(makeReq({ authorization: 'Bearer bad-token' }), res);
+
+    expect(verifier.verify).toHaveBeenCalledWith('bad-token');
+    expect(res.header).toHaveBeenCalledWith(
+      'WWW-Authenticate',
+      'Bearer realm="mcp", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"',
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Unauthorized' },
+      id: null,
+    });
+  });
+
+  it('path-inserts a custom endpoint and honors an explicit resourceMetadataUrl', async () => {
+    const verifier = { verify: vi.fn() };
+
+    const { service: customEndpoint } = makeService(
+      makeServiceOptions({ endpoint: 'my/mcp', oauth: { enabled: true } }),
+      verifier,
+    );
+    const res1 = makeExpressRes();
+    await customEndpoint.handlePostRequest(makeReq(), res1);
+    expect(res1.setHeader).toHaveBeenCalledWith(
+      'WWW-Authenticate',
+      'Bearer realm="mcp", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/my/mcp"',
+    );
+
+    const { service: explicitUrl } = makeService(
+      makeServiceOptions({
+        oauth: { enabled: true, resourceMetadataUrl: 'https://meta.example.com/resource' },
+      }),
+      verifier,
+    );
+    const res2 = makeExpressRes();
+    await explicitUrl.handlePostRequest(makeReq(), res2);
+    expect(res2.setHeader).toHaveBeenCalledWith(
+      'WWW-Authenticate',
+      'Bearer realm="mcp", resource_metadata="https://meta.example.com/resource"',
+    );
+  });
+
+  it('sets req.auth on a valid bearer token and forwards to the transport', async () => {
+    const authInfo = makeAuthInfo('user-a');
+    const verifier = { verify: vi.fn().mockResolvedValue(authInfo) };
+    const { service } = makeService(makeServiceOptions({ oauth: { enabled: true } }), verifier);
+    const req = makeReq({ authorization: 'Bearer token-user-a' });
+    const res = makeExpressRes();
+
+    await service.handlePostRequest(req, res);
+
+    expect(verifier.verify).toHaveBeenCalledWith('token-user-a');
+    expect(req.auth).toBe(authInfo);
+    expect(lastTransport().handleRequest).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it('passes through anonymously when required is false and no token is sent', async () => {
+    const verifier = { verify: vi.fn() };
+    const { service } = makeService(
+      makeServiceOptions({ oauth: { enabled: true, required: false } }),
+      verifier,
+    );
+    const req = makeReq();
+    const res = makeExpressRes();
+
+    await service.handlePostRequest(req, res);
+
+    expect(req.auth).toBeUndefined();
+    expect(res.statusCode).toBeUndefined();
+    expect(lastTransport().handleRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('responds 500 on first request when oauth is enabled but no verifier is resolvable', async () => {
+    const { service } = makeService(makeServiceOptions({ oauth: { enabled: true } }));
+    const res = makeExpressRes();
+
+    await service.handlePostRequest(makeReq({ authorization: 'Bearer t' }), res);
+
+    expect(res.statusCode).toBe(500);
+    expect(hoisted.transports).toHaveLength(0);
+  });
+
+  it('logs a bootstrap warning when oauth is enabled but no verifier is resolvable', () => {
+    const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    try {
+      const { service } = makeService(makeServiceOptions({ oauth: { enabled: true } }));
+      service.onModuleInit();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('MCP_BEARER_TOKEN_VERIFIER'));
+
+      warnSpy.mockClear();
+      const verifier = { verify: vi.fn() };
+      const { service: configured } = makeService(
+        makeServiceOptions({ oauth: { enabled: true } }),
+        verifier,
+      );
+      configured.onModuleInit();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not authenticate when oauth is not enabled', async () => {
+    const { service } = makeService(makeServiceOptions());
+    const req = makeReq();
+    const res = makeExpressRes();
+
+    await service.handlePostRequest(req, res);
+
+    expect(req.auth).toBeUndefined();
+    expect(res.statusCode).toBeUndefined();
+    expect(lastTransport().handleRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('StreamableHttpService session-identity binding', () => {
+  beforeEach(() => {
+    hoisted.transports.length = 0;
+  });
+
+  /** Initializes session `sess-1` bound to the given principal. */
+  async function initializeSession(verifier: { verify: ReturnType<typeof vi.fn> }, sub = 'user-a') {
+    const { service } = makeService(makeServiceOptions({ oauth: { enabled: true } }), verifier);
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo(sub));
+    await service.handlePostRequest(
+      makeReq({ authorization: `Bearer token-${sub}` }),
+      makeExpressRes(),
+    );
+    return { service, transport: lastTransport() };
+  }
+
+  it('responds 403 on POST to a session owned by another principal', async () => {
+    const verifier = { verify: vi.fn() };
+    const { service, transport } = await initializeSession(verifier);
+
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo('user-b'));
+    const res = makeExpressRes();
+    await service.handlePostRequest(
+      makeReq({ authorization: 'Bearer token-user-b', 'mcp-session-id': 'sess-1' }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: 'Session does not belong to this principal' });
+    expect(transport.handleRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('responds 403 on GET from another principal and allows the owner', async () => {
+    const verifier = { verify: vi.fn() };
+    const { service, transport } = await initializeSession(verifier);
+
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo('user-b'));
+    const forbidden = makeExpressRes();
+    await service.handleGetRequest(
+      makeReq({ authorization: 'Bearer token-user-b', 'mcp-session-id': 'sess-1' }),
+      forbidden,
+    );
+    expect(forbidden.statusCode).toBe(403);
+    expect(forbidden.body).toEqual({ error: 'Session does not belong to this principal' });
+
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo('user-a'));
+    const allowed = makeExpressRes();
+    await service.handleGetRequest(
+      makeReq({ authorization: 'Bearer token-user-a', 'mcp-session-id': 'sess-1' }),
+      allowed,
+    );
+    expect(allowed.statusCode).toBeUndefined();
+    expect(transport.handleRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('responds 403 on DELETE from another principal without closing the session', async () => {
+    const verifier = { verify: vi.fn() };
+    const { service, transport } = await initializeSession(verifier);
+
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo('user-b'));
+    const forbidden = makeExpressRes();
+    await service.handleDeleteRequest(
+      makeReq({ authorization: 'Bearer token-user-b', 'mcp-session-id': 'sess-1' }),
+      forbidden,
+    );
+    expect(forbidden.statusCode).toBe(403);
+    expect(transport.close).not.toHaveBeenCalled();
+
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo('user-a'));
+    const allowed = makeExpressRes();
+    await service.handleDeleteRequest(
+      makeReq({ authorization: 'Bearer token-user-a', 'mcp-session-id': 'sess-1' }),
+      allowed,
+    );
+    expect(allowed.statusCode).toBe(204);
+    expect(transport.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects requests from a different client of the same user', async () => {
+    const verifier = { verify: vi.fn() };
+    const { service } = await initializeSession(verifier);
+
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo('user-a', 'client-2'));
+    const res = makeExpressRes();
+    await service.handlePostRequest(
+      makeReq({ authorization: 'Bearer token-user-a', 'mcp-session-id': 'sess-1' }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('skips binding entirely when oauth is not enabled', async () => {
+    const { service } = makeService(makeServiceOptions());
+    await service.handlePostRequest(makeReq(), makeExpressRes());
+    const transport = lastTransport();
+
+    const res = makeExpressRes();
+    await service.handleGetRequest(makeReq({ 'mcp-session-id': 'sess-1' }), res);
+
+    expect(res.statusCode).toBeUndefined();
+    expect(transport.handleRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips binding when bindSessionToUser is false', async () => {
+    const verifier = { verify: vi.fn() };
+    const { service } = makeService(
+      makeServiceOptions({ oauth: { enabled: true, bindSessionToUser: false } }),
+      verifier,
+    );
+
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo('user-a'));
+    await service.handlePostRequest(
+      makeReq({ authorization: 'Bearer token-user-a' }),
+      makeExpressRes(),
+    );
+    const transport = lastTransport();
+
+    verifier.verify.mockResolvedValueOnce(makeAuthInfo('user-b'));
+    const res = makeExpressRes();
+    await service.handlePostRequest(
+      makeReq({ authorization: 'Bearer token-user-b', 'mcp-session-id': 'sess-1' }),
+      res,
+    );
+
+    expect(res.statusCode).toBeUndefined();
+    expect(transport.handleRequest).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('StreamableHttpService DNS-rebinding option forwarding', () => {
+  beforeEach(() => {
+    hoisted.transports.length = 0;
+  });
+
+  it('forwards allowedHosts, allowedOrigins, and enableDnsRebindingProtection to the SDK transport', async () => {
+    const { service } = makeService(
+      makeServiceOptions({
+        allowedHosts: ['api.example.com'],
+        allowedOrigins: ['https://app.example.com'],
+        enableDnsRebindingProtection: true,
+      }),
+    );
+
+    await service.handlePostRequest(makeReq(), makeExpressRes());
+
+    const transport = lastTransport();
+    expect(transport.options.allowedHosts).toEqual(['api.example.com']);
+    expect(transport.options.allowedOrigins).toEqual(['https://app.example.com']);
+    expect(transport.options.enableDnsRebindingProtection).toBe(true);
+  });
+
+  it('leaves DNS-rebinding options undefined when not configured', async () => {
+    const { service } = makeService(makeServiceOptions());
+
+    await service.handlePostRequest(makeReq(), makeExpressRes());
+
+    const transport = lastTransport();
+    expect(transport.options.allowedHosts).toBeUndefined();
+    expect(transport.options.allowedOrigins).toBeUndefined();
+    expect(transport.options.enableDnsRebindingProtection).toBeUndefined();
   });
 });

--- a/packages/server/src/transport/streamable-http/streamable.service.ts
+++ b/packages/server/src/transport/streamable-http/streamable.service.ts
@@ -3,10 +3,23 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { StreamableHTTPServerTransportOptions } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import type { McpExecutionContext, McpModuleOptions } from '@nest-mcp/common';
+import type { McpAuthInfo, McpExecutionContext, McpModuleOptions } from '@nest-mcp/common';
 import { MCP_OPTIONS } from '@nest-mcp/common';
 import { McpTransportType } from '@nest-mcp/common';
-import { Inject, Injectable, Logger, type OnModuleDestroy, Optional } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  type OnModuleInit,
+  Optional,
+} from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import {
+  type BearerTokenVerifier,
+  MCP_BEARER_TOKEN_VERIFIER,
+} from '../../auth/services/bearer-verifier.service';
+import { DEFAULT_MCP_ENDPOINT } from '../../constants/module.constants';
 import type {
   RegisteredPrompt,
   RegisteredResource,
@@ -32,6 +45,8 @@ import type { SdkHandle } from '../register-handlers';
 interface HttpRequest {
   headers?: Record<string, string | string[] | undefined>;
   headersSent?: boolean;
+  /** Verified bearer identity; the SDK transport reads this and surfaces it as `authInfo`. */
+  auth?: McpAuthInfo;
 }
 
 interface HttpResponse {
@@ -39,16 +54,24 @@ interface HttpResponse {
   status?: (code: number) => { json?: (body: unknown) => void; end?: () => void };
   code?: (code: number) => { send?: (body?: unknown) => void };
   on?: (event: string, cb: () => void) => void;
+  /** Express / Node `ServerResponse` header setter. */
+  setHeader?: (name: string, value: string) => unknown;
+  /** Fastify reply header setter. */
+  header?: (name: string, value: string) => unknown;
 }
 
 @Injectable()
-export class StreamableHttpService implements OnModuleDestroy {
+export class StreamableHttpService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(StreamableHttpService.name);
   private readonly transports = new Map<string, StreamableHTTPServerTransport>();
   private readonly servers = new Map<string, McpServer>();
   private readonly contexts = new Map<string, McpExecutionContext>();
   /** SDK handles per session, keyed by item name/uri for removal. */
   private readonly sdkHandles = new Map<string, Map<string, SdkHandle>>();
+  /** Principal each stateful session was initialized by (oauth session binding). */
+  private readonly sessionAuth = new Map<string, { sub?: string; clientId: string }>();
+  /** Lazily resolved bearer-token verifier (cached on first successful resolution). */
+  private bearerVerifier?: BearerTokenVerifier;
 
   private readonly registryListeners: Array<{
     event: string;
@@ -61,18 +84,49 @@ export class StreamableHttpService implements OnModuleDestroy {
     private readonly executor: McpExecutorService,
     private readonly pipeline: ExecutionPipelineService,
     private readonly contextFactory: McpContextFactory,
+    private readonly moduleRef: ModuleRef,
     @Optional() private readonly subscriptionManager?: ResourceSubscriptionManager,
     @Optional() private readonly taskManager?: TaskManager,
   ) {
     this.subscribeToRegistryEvents();
   }
 
+  onModuleInit(): void {
+    if (this.oauthOptions?.enabled && !this.resolveBearerVerifier()) {
+      this.logger.warn(
+        'streamableHttp.oauth.enabled is set but no MCP_BEARER_TOKEN_VERIFIER provider could be resolved. ' +
+          'Import McpAuthModule.forRoot(...) or provide MCP_BEARER_TOKEN_VERIFIER — requests will fail until then.',
+      );
+    }
+  }
+
   get isStateless(): boolean {
     return this.options.transportOptions?.streamableHttp?.stateless ?? false;
   }
 
+  private get oauthOptions() {
+    return this.options.transportOptions?.streamableHttp?.oauth;
+  }
+
+  private resolveBearerVerifier(): BearerTokenVerifier | undefined {
+    if (this.bearerVerifier) return this.bearerVerifier;
+    try {
+      this.bearerVerifier = this.moduleRef.get<BearerTokenVerifier>(MCP_BEARER_TOKEN_VERIFIER, {
+        strict: false,
+      });
+    } catch {
+      // Not registered — handled by the caller.
+    }
+    return this.bearerVerifier;
+  }
+
   async handlePostRequest(req: unknown, res: unknown): Promise<void> {
     try {
+      if (this.oauthOptions?.enabled) {
+        const auth = await this.authenticate(req, res);
+        if (auth === 'responded') return;
+      }
+
       if (this.isStateless) {
         await this.handleStatelessPost(req, res);
       } else {
@@ -90,6 +144,11 @@ export class StreamableHttpService implements OnModuleDestroy {
 
   async handleGetRequest(req: unknown, res: unknown): Promise<void> {
     const resObj = res as HttpResponse;
+    if (this.oauthOptions?.enabled) {
+      const auth = await this.authenticate(req, res);
+      if (auth === 'responded') return;
+    }
+
     if (this.isStateless) {
       resObj.status?.(405).json?.({ error: 'SSE not supported in stateless mode' }) ??
         resObj.code?.(405).send?.({ error: 'SSE not supported in stateless mode' });
@@ -104,6 +163,8 @@ export class StreamableHttpService implements OnModuleDestroy {
       return;
     }
 
+    if (!this.enforceSessionBinding(sessionId, req, res)) return;
+
     const transport = this.transports.get(sessionId);
     if (transport) {
       await transport.handleRequest(
@@ -116,8 +177,14 @@ export class StreamableHttpService implements OnModuleDestroy {
   async handleDeleteRequest(req: unknown, res: unknown): Promise<void> {
     const reqObj = req as HttpRequest;
     const resObj = res as HttpResponse;
+    if (this.oauthOptions?.enabled) {
+      const auth = await this.authenticate(req, res);
+      if (auth === 'responded') return;
+    }
+
     const sessionId = reqObj.headers?.['mcp-session-id'] as string | undefined;
     if (sessionId && this.transports.has(sessionId)) {
+      if (!this.enforceSessionBinding(sessionId, req, res)) return;
       await this.cleanupSession(sessionId);
       resObj.status?.(204).end?.() ?? resObj.code?.(204).send?.();
     } else {
@@ -137,7 +204,112 @@ export class StreamableHttpService implements OnModuleDestroy {
       onsessioninitialized: opts?.onsessioninitialized,
       onsessionclosed: opts?.onsessionclosed,
       retryInterval: opts?.retryInterval,
+      allowedHosts: opts?.allowedHosts,
+      allowedOrigins: opts?.allowedOrigins,
+      enableDnsRebindingProtection: opts?.enableDnsRebindingProtection,
     };
+  }
+
+  /**
+   * Bearer-token gate applied when `streamableHttp.oauth.enabled` is set.
+   *
+   * - valid token: attaches the identity to `req.auth` (the SDK transport
+   *   surfaces it as `authInfo`) and returns it.
+   * - missing/invalid token while auth is required: responds 401 with a
+   *   `WWW-Authenticate` challenge and returns `'responded'`.
+   * - no valid token while `required === false`: returns `undefined`
+   *   (anonymous passthrough).
+   */
+  private async authenticate(
+    req: unknown,
+    res: unknown,
+  ): Promise<McpAuthInfo | 'responded' | undefined> {
+    const oauth = this.oauthOptions;
+    if (!oauth?.enabled) return undefined;
+
+    const verifier = this.resolveBearerVerifier();
+    if (!verifier) {
+      throw new Error(
+        'StreamableHttpService: streamableHttp.oauth.enabled is set but no MCP_BEARER_TOKEN_VERIFIER ' +
+          'provider could be resolved. Import McpAuthModule.forRoot(...) or provide MCP_BEARER_TOKEN_VERIFIER.',
+      );
+    }
+
+    const reqObj = req as HttpRequest;
+    const rawHeader = reqObj.headers?.authorization;
+    const headerValue = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+    const [scheme, token] = headerValue?.split(' ') ?? [];
+
+    let authInfo: McpAuthInfo | null = null;
+    if (scheme?.toLowerCase() === 'bearer' && token) {
+      authInfo = await verifier.verify(token);
+    }
+
+    if (authInfo) {
+      reqObj.auth = authInfo;
+      return authInfo;
+    }
+
+    if (oauth.required === false) return undefined;
+
+    this.respondUnauthorized(req, res);
+    return 'responded';
+  }
+
+  private respondUnauthorized(req: unknown, res: unknown): void {
+    const resObj = res as HttpResponse;
+    if (resObj.headersSent) return;
+
+    const challenge = `Bearer realm="mcp", resource_metadata="${this.resourceMetadataUrl(req)}"`;
+    if (typeof resObj.setHeader === 'function') {
+      resObj.setHeader('WWW-Authenticate', challenge);
+    } else {
+      resObj.header?.('WWW-Authenticate', challenge);
+    }
+
+    const body = {
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Unauthorized' },
+      id: null,
+    };
+    resObj.status?.(401).json?.(body) ?? resObj.code?.(401).send?.(body);
+  }
+
+  /** RFC 9728 protected-resource metadata URL (path-insertion form by default). */
+  private resourceMetadataUrl(req: unknown): string {
+    const configured = this.oauthOptions?.resourceMetadataUrl;
+    if (configured) return configured;
+
+    const rawHost = (req as HttpRequest).headers?.host;
+    const host = (Array.isArray(rawHost) ? rawHost[0] : rawHost) ?? 'localhost';
+    const endpoint =
+      this.options.transportOptions?.streamableHttp?.endpoint ?? DEFAULT_MCP_ENDPOINT;
+    const path = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+    return `https://${host}/.well-known/oauth-protected-resource${path}`;
+  }
+
+  /**
+   * Verifies the current request's principal matches the one the session was
+   * initialized by. Responds 403 and returns false on mismatch. No-op unless
+   * oauth is enabled, binding is on, and a binding was recorded.
+   */
+  private enforceSessionBinding(sessionId: string, req: unknown, res: unknown): boolean {
+    const oauth = this.oauthOptions;
+    if (!oauth?.enabled || oauth.bindSessionToUser === false) return true;
+
+    const bound = this.sessionAuth.get(sessionId);
+    if (!bound) return true;
+
+    const auth = (req as HttpRequest).auth;
+    const sub = auth?.extra?.sub as string | undefined;
+    if (auth && auth.clientId === bound.clientId && sub === bound.sub) return true;
+
+    const resObj = res as HttpResponse;
+    if (!resObj.headersSent) {
+      const body = { error: 'Session does not belong to this principal' };
+      resObj.status?.(403).json?.(body) ?? resObj.code?.(403).send?.(body);
+    }
+    return false;
   }
 
   private async handleStatelessPost(req: unknown, res: unknown): Promise<void> {
@@ -166,6 +338,7 @@ export class StreamableHttpService implements OnModuleDestroy {
     const existingSessionId = reqObj.headers?.['mcp-session-id'] as string | undefined;
 
     if (existingSessionId && this.transports.has(existingSessionId)) {
+      if (!this.enforceSessionBinding(existingSessionId, req, res)) return;
       const transport = this.transports.get(existingSessionId);
       if (transport) {
         await transport.handleRequest(
@@ -195,6 +368,16 @@ export class StreamableHttpService implements OnModuleDestroy {
     if (sessionId) {
       this.transports.set(sessionId, transport);
       this.servers.set(sessionId, server);
+
+      const oauth = this.oauthOptions;
+      const auth = reqObj.auth;
+      if (oauth?.enabled && oauth.bindSessionToUser !== false && auth) {
+        this.sessionAuth.set(sessionId, {
+          sub: auth.extra?.sub as string | undefined,
+          clientId: auth.clientId,
+        });
+      }
+
       this.logger.log(`New session: ${sessionId}`);
     }
   }
@@ -381,6 +564,7 @@ export class StreamableHttpService implements OnModuleDestroy {
     this.servers.delete(sessionId);
     this.contexts.delete(sessionId);
     this.sdkHandles.delete(sessionId);
+    this.sessionAuth.delete(sessionId);
 
     if (transport) {
       await transport.close();

--- a/packages/server/src/utils/resolve-guard.util.spec.ts
+++ b/packages/server/src/utils/resolve-guard.util.spec.ts
@@ -1,0 +1,43 @@
+import 'reflect-metadata';
+import type { McpGuardClass } from '@nest-mcp/common';
+import { resolveGuard } from './resolve-guard.util';
+
+describe('resolveGuard', () => {
+  let moduleRef: { get: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    moduleRef = { get: vi.fn() };
+  });
+
+  it('resolves the guard from DI when registered as a provider', () => {
+    const diGuard = { canActivate: vi.fn().mockReturnValue(true) };
+    moduleRef.get.mockReturnValue(diGuard);
+    const GuardClass = class DiGuard {} as unknown as McpGuardClass;
+
+    const guard = resolveGuard(
+      moduleRef as unknown as Parameters<typeof resolveGuard>[0],
+      GuardClass,
+    );
+
+    expect(moduleRef.get).toHaveBeenCalledWith(GuardClass, { strict: false });
+    expect(guard).toBe(diGuard);
+  });
+
+  it('falls back to bare new when the guard is not in DI', () => {
+    moduleRef.get.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    class SimpleGuard {
+      canActivate() {
+        return true;
+      }
+    }
+
+    const guard = resolveGuard(
+      moduleRef as unknown as Parameters<typeof resolveGuard>[0],
+      SimpleGuard as unknown as McpGuardClass,
+    );
+
+    expect(guard).toBeInstanceOf(SimpleGuard);
+  });
+});

--- a/packages/server/src/utils/resolve-guard.util.ts
+++ b/packages/server/src/utils/resolve-guard.util.ts
@@ -1,0 +1,16 @@
+import type { McpGuard, McpGuardClass } from '@nest-mcp/common';
+import type { ModuleRef } from '@nestjs/core';
+
+/**
+ * Resolves a guard class through Nest DI when it is registered as a provider
+ * (so constructor-injected dependencies work), falling back to a bare `new`
+ * for simple guards that are not part of any module.
+ */
+export function resolveGuard(moduleRef: ModuleRef, GuardClass: McpGuardClass): McpGuard {
+  try {
+    return moduleRef.get(GuardClass, { strict: false });
+  } catch {
+    // Guard not in DI — instantiate directly (for simple guards)
+    return new (GuardClass as new () => McpGuard)();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,7 +314,7 @@ importers:
         version: link:../common
     devDependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
+        specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
       '@nestjs/common':
         specifier: ^11.0.0
@@ -372,7 +372,7 @@ importers:
         version: link:../server
     devDependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
+        specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
       '@nestjs/common':
         specifier: ^11.0.0
@@ -409,7 +409,7 @@ importers:
         version: 8.3.0
     devDependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.10.0
+        specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
       '@nestjs/common':
         specifier: ^11.0.0


### PR DESCRIPTION
## Summary

Hardens the streamable HTTP transport + McpAuthModule for spec-compliant remote MCP OAuth (changesets included: minor for `@nest-mcp/server` + `@nest-mcp/common`, patch for client/gateway SDK-peer bump).

- **Per-request auth context**: tool/resource/prompt handlers and guards now see the CURRENT request via SDK `authInfo`/`requestInfo` instead of the session's captured initialize request (fixes stale-credential reuse within a session). Behavioral note: `ctx.request` is now the per-request `RequestInfo` (`{ headers }`).
- **Transport `oauth` option**: bearer verification at the HTTP edge (pluggable `MCP_BEARER_TOKEN_VERIFIER`), `401` + `WWW-Authenticate: Bearer resource_metadata=...` (RFC 9728) for client OAuth discovery, session-to-principal binding (cross-principal replay → 403).
- **DNS-rebinding options** passthrough (`allowedHosts`/`allowedOrigins`/`enableDnsRebindingProtection`).
- **`filterListsByScopes`**: tools/resources/prompts lists filtered by the caller's token scopes (opt-in).
- **Guard DI**: guards resolve through `ModuleRef` with bare-`new` fallback (pipeline + tool-auth).
- **Well-known compliance**: `introspection_endpoint`, RFC 8414/9728 path-insertion routes (Nest 10/11), `aud` = resource (RFC 8707), access tokens gain `jti`.
- **`McpAuthModule.forRootAsync`** + store-override factory; optional `IOAuthStore.recordIssuedToken` hook (access+refresh, incl. refresh grants); refresh path consults `isTokenRevoked`.
- **Fix**: refresh JWTs now carry the `scope` claim so refreshed access tokens keep their scopes.
- SDK peer floor `^1.26.0`; docs updated (`transports.md`, `auth.md`); 6 new oauth-gate smoke tests through the real JWT→verifier→store stack.

## Testing

Full uncached gate: `pnpm turbo run build typecheck lint test` — 23/23 tasks, 1746+ tests passing. Battle-tested downstream by vatos-data-layer's 20-test OAuth e2e (DCR → consent → PKCE → tools/call → refresh → revoke) against a packed build of this branch.