### PR TITLE
feat: server hardening — transport e2e suite, request-scoped DI, instructions, setLevel fix

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "nest-mcp",
+  "description": "NestJS packages for the Model Context Protocol: @nest-mcp/server (decorator-based MCP servers with auth, resilience, exposure strategies), @nest-mcp/client (MCP client for NestJS), @nest-mcp/gateway (MCP aggregator/router), @nest-mcp/common (shared interfaces).",
+  "folders": ["docs", "packages/server/src", "packages/client/src", "packages/gateway/src", "packages/common/src"],
+  "excludeFolders": ["node_modules", "dist", "references", "internal-docs"],
+  "excludeFiles": ["*.spec.ts"],
+  "rules": [
+    "Create MCP servers with McpModule.forRoot and the @Tool/@Resource/@ResourceTemplate/@Prompt/@Completion decorators",
+    "Bootstrap HTTP transports with NestFactory.create(AppModule, { bodyParser: false }) — transports read the raw request stream",
+    "Auth is resource-server-only: bring an external IdP via the jwks or introspection verifier options on McpAuthModule.forRoot",
+    "Use bootstrapStdioApp() for STDIO servers so logs go to stderr",
+    "Tool handlers receive (args, ctx: McpExecutionContext); per-request data (user, headers, signal) comes from ctx"
+  ]
+}

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -39,7 +39,8 @@ import { ToolsService } from './tools.service';
 class AppModule {}
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  // bodyParser: false — the MCP transports read the raw request stream
+  const app = await NestFactory.create(AppModule, { bodyParser: false });
   await app.listen(3000);
 }
 bootstrap();
@@ -81,6 +82,7 @@ export class ToolsService {
 |-------|-------------|
 | [Getting Started](./getting-started.md) | Minimal working example |
 | [Module](./module.md) | `McpModule.forRoot` / `forRootAsync` / `forFeature` |
+| [Dependency Injection](./dependency-injection.md) | Singleton vs request-scoped providers, `REQUEST` injection |
 | [Decorators](./decorators.md) | `@Tool`, `@Resource`, `@ResourceTemplate`, `@Prompt`, `@Completion` |
 | [Auth Decorators](./auth-decorators.md) | `@Public`, `@Scopes`, `@Roles`, `@Guards` |
 | [Resilience Decorators](./resilience-decorators.md) | `@RateLimit`, `@Retry`, `@CircuitBreaker`, `@Timeout` |
@@ -88,6 +90,8 @@ export class ToolsService {
 | [Auth](./auth.md) | `McpAuthModule`, OAuth resource server, verifiers, guards |
 | [Resilience](./resilience.md) | Rate limiter, circuit breaker, retry services |
 | [Middleware](./middleware.md) | `@UseMiddleware`, `MiddlewareService` |
+| [Elicitation](./elicitation.md) | `ctx.elicit` protocol elicitation, `McpElicitationModule` HTTP fallback |
+| [Exposure](./exposure.md) | Catalog presentation: eager/search/lazy strategies, per-client resolvers |
 | [Dynamic Builders](./dynamic-builders.md) | `McpToolBuilder`, `McpResourceBuilder`, `McpPromptBuilder` |
 | [Execution Pipeline](./execution-pipeline.md) | Request lifecycle |
 | [Sessions](./sessions.md) | `SessionManager`, `ResourceSubscriptionManager`, `TaskManager` |

--- a/docs/server/dependency-injection.md
+++ b/docs/server/dependency-injection.md
@@ -1,0 +1,83 @@
+# Dependency Injection
+
+MCP feature providers (`@Tool`, `@Resource`, `@ResourceTemplate`, `@Prompt`,
+`@Completion`) are plain NestJS providers: constructor injection, module
+imports, and `forFeature` scoping all work as usual. This page covers the two
+scoping models and how per-request data reaches your handlers.
+
+## Singleton providers (default)
+
+Providers with the default scope are discovered once at boot and invoked as
+singletons. This is the right choice for almost all tools:
+
+```typescript
+@Injectable()
+export class WeatherTools {
+  constructor(private readonly weather: WeatherService) {}
+
+  @Tool({ name: 'get-forecast', description: 'Get forecast', parameters: z.object({ city: z.string() }) })
+  getForecast({ city }: { city: string }, ctx: McpExecutionContext) {
+    // per-request data comes in through the context, not the constructor
+    ctx.log.info(`forecast for ${city}`, { user: ctx.user?.id });
+    return this.weather.forecast(city);
+  }
+}
+```
+
+### Per-request data on the context
+
+Singleton handlers receive everything request-specific through the
+`McpExecutionContext` second argument:
+
+| Field | Contents |
+|-------|----------|
+| `ctx.request` | The HTTP request info that delivered this JSON-RPC message (`{ headers }` on streamable HTTP) |
+| `ctx.user` | Authenticated user derived from the verified bearer token |
+| `ctx.authInfo` | Raw verified token identity (scopes, clientId, claims) |
+| `ctx.sessionId` / `ctx.transport` | Session and transport of the call |
+| `ctx.signal` | Abort signal (client cancellation) |
+
+Prefer the context over request-scoped DI — it has no per-call instantiation
+cost and works identically on every transport (including STDIO, which has no
+HTTP request).
+
+## Request-scoped providers
+
+Providers declared with `Scope.REQUEST` (or `Scope.TRANSIENT`, or any provider
+whose dependency tree contains one) are also discovered at boot — by class —
+and a **fresh instance is resolved for every call**. The MCP request info is
+registered as the `REQUEST` token, so `@Inject(REQUEST)` works:
+
+```typescript
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+
+@Injectable({ scope: Scope.REQUEST })
+export class TenantTools {
+  constructor(@Inject(REQUEST) private readonly request: { headers?: Record<string, unknown> }) {}
+
+  @Tool({ name: 'whoami', description: 'Echo the calling tenant', parameters: z.object({}) })
+  whoami() {
+    return `tenant:${this.request?.headers?.['x-tenant'] ?? 'anonymous'}`;
+  }
+}
+```
+
+Notes:
+
+- The injected `REQUEST` value is the **MCP request info** (`{ headers }`),
+  not a full Express/Fastify request object. On transports without per-message
+  HTTP requests (STDIO), it is the transport-level request or `undefined` —
+  guard accordingly.
+- Resolution happens per capability call (`tools/call`, `resources/read`,
+  `prompts/get`, `completion/complete`), so request-scoped dependencies (e.g.
+  a per-tenant database connection) are constructed per call and garbage
+  collected afterwards. Expect the usual request-scope instantiation overhead.
+- Listing endpoints (`tools/list` etc.) never instantiate providers; they use
+  the metadata captured at scan time.
+
+## See Also
+
+- [Module configuration](./module.md)
+- [Decorators](./decorators.md)
+- [Execution pipeline](./execution-pipeline.md)

--- a/docs/server/elicitation.md
+++ b/docs/server/elicitation.md
@@ -1,0 +1,71 @@
+# Elicitation
+
+Two complementary ways to ask the user for input during a tool call:
+
+1. **Protocol elicitation** (`ctx.elicit`) — for MCP clients that declare the
+   `elicitation` capability. The request travels over the MCP connection and
+   the client renders the form.
+2. **HTTP elicitation** (`McpElicitationModule`) — browser-based fallback for
+   clients without elicitation support. The server hosts a small form UI and
+   hands the user a URL.
+
+## Protocol elicitation (`ctx.elicit`)
+
+Inside any tool handler, ask the connected client for structured input:
+
+```typescript
+@Tool({ name: 'delete-repo', description: 'Delete a repository', parameters: z.object({ name: z.string() }) })
+async deleteRepo({ name }: { name: string }, ctx: McpExecutionContext) {
+  if (!ctx.elicit) {
+    return { isError: true, content: [{ type: 'text', text: 'Client does not support elicitation' }] };
+  }
+
+  const answer = await ctx.elicit({
+    message: `Really delete ${name}?`,
+    requestedSchema: {
+      type: 'object',
+      properties: { confirm: { type: 'boolean', description: 'Type yes to confirm' } },
+      required: ['confirm'],
+    },
+  });
+
+  if (answer.action !== 'accept' || !answer.content?.confirm) {
+    return 'Cancelled.';
+  }
+  return await this.repos.delete(name);
+}
+```
+
+`ctx.elicit` is `undefined` when the transport/client cannot deliver
+elicitation requests — always guard.
+
+## HTTP elicitation (`McpElicitationModule`)
+
+Hosts `GET/POST /<apiPrefix>/:elicitationId` routes that render a themed form
+and collect the response out-of-band:
+
+```typescript
+@Module({
+  imports: [
+    McpElicitationModule.forRoot({
+      serverUrl: 'https://api.example.com', // used to build user-facing URLs
+      apiPrefix: 'elicitation',             // default
+      elicitationTtlMs: 60 * 60 * 1000,     // default 1h
+      storeConfiguration: { type: 'memory' }, // or { type: 'custom', store }
+      guards: [SessionGuard],               // applied to every elicitation route
+      templateOptions: { appName: 'My Server', primaryColor: '#0a7', logoUrl: '...' },
+    }),
+  ],
+})
+class AppModule {}
+```
+
+Inject `ElicitationService` in a tool to create a pending elicitation, return
+its URL to the model, and await the user's submission. Stores implement
+`IElicitationStore` (in-memory provided; bring your own for multi-instance
+deployments).
+
+## See Also
+
+- [Module configuration](./module.md)
+- [Sessions](./sessions.md)

--- a/docs/server/exposure.md
+++ b/docs/server/exposure.md
@@ -1,0 +1,69 @@
+# Exposure Strategies
+
+Exposure controls how `tools/list` presents your catalog to clients. With
+dozens or hundreds of tools, listing every full schema eagerly wastes the
+model's context window — exposure strategies defer the long tail behind
+meta-tools while keeping a curated subset eager. Execution (`tools/call`) is
+unaffected.
+
+## Strategies
+
+Configured via `McpModule.forRoot({ exposure })`:
+
+| Kind | Behavior |
+|------|----------|
+| `{ kind: 'eager' }` | Default. Every tool with its full schema in `tools/list` |
+| `{ kind: 'search', variant: 'regex' \| 'bm25' }` | Anthropic Tool Search Tool style: eager subset + a search meta-tool that discovers the rest |
+| `{ kind: 'lazy' }` | Eager subset + `list_available_tools` index meta-tool + `get_tool_schema` batch schema fetch |
+| `{ kind: 'typed-api' }` | Tool catalog presented as a typed API surface |
+
+The `eager` selector picks which tools stay fully listed, in any of three
+forms:
+
+```typescript
+exposure: { kind: 'lazy', eager: ['search-docs', 'get-status'] }      // exact names
+exposure: { kind: 'lazy', eager: { tags: ['core'] } }                  // by @Tool({ tags })
+exposure: { kind: 'lazy', eager: (meta) => meta.name.startsWith('q') } // predicate
+```
+
+### Lazy strategy options
+
+```typescript
+exposure: {
+  kind: 'lazy',
+  eager: { tags: ['core'] },
+  indexToolName: 'list_available_tools', // default
+  schemaToolName: 'get_tool_schema',     // default
+  indexFields: ['name', 'description', 'tags'],
+  maxBatchSize: 20,
+  requireDiscovery: false, // true rejects calls to undiscovered deferred tools
+}
+```
+
+## Per-tool override
+
+`@Tool({ exposure: 'eager' | 'deferred' | 'auto' })` overrides the module
+strategy for that tool (decorator wins).
+
+## Per-client strategies
+
+Pass a resolver instead of a static strategy to tier clients (e.g. give
+search-capable clients the search strategy and everyone else lazy):
+
+```typescript
+import { defineResolver, preferSearchElseLazy } from '@nest-mcp/common';
+
+exposure: preferSearchElseLazy({ eager: { tags: ['core'] } })
+// or a custom resolver over ClientContext (clientInfo, betaHeaders, transport).
+// The first argument declares which strategy kinds the resolver may return:
+exposure: defineResolver(['search', 'lazy'], (client) =>
+  client.betaHeaders?.includes('tool-search-tool-2025-10-19')
+    ? { kind: 'search', variant: 'bm25' }
+    : { kind: 'lazy' },
+)
+```
+
+## See Also
+
+- [Module configuration](./module.md)
+- [Decorators](./decorators.md)

--- a/docs/server/getting-started.md
+++ b/docs/server/getting-started.md
@@ -64,7 +64,10 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  // bodyParser must be disabled: the MCP transports read the raw
+  // request stream themselves. A pre-consumed body surfaces as
+  // JSON-RPC -32700 "Parse error: Invalid JSON".
+  const app = await NestFactory.create(AppModule, { bodyParser: false });
   await app.listen(3000);
 }
 bootstrap();

--- a/docs/server/module.md
+++ b/docs/server/module.md
@@ -29,11 +29,13 @@ export class AppModule {}
 |--------|------|----------|-------------|
 | `name` | `string` | Yes | Server name reported to clients |
 | `version` | `string` | Yes | Server version |
-| `description` | `string` | No | Server description |
+| `description` | `string` | No | Server description (human-facing metadata) |
+| `instructions` | `string` | No | LLM guidance returned verbatim on `initialize`. Falls back to `description` when omitted |
 | `transport` | `McpTransportType \| McpTransportType[]` | Yes | One or more transports to enable |
 | `transportOptions` | `TransportOptions` | No | Per-transport configuration |
 | `guards` | `McpGuardClass[]` | No | Global guards applied to all requests |
 | `allowUnauthenticatedAccess` | `boolean` | No | Skip auth for all handlers |
+| `advertiseSecuritySchemes` | `boolean` | No | Advertise per-tool auth requirements in `tools/list` `_meta.securitySchemes` (`noauth` for `@Public` tools, `oauth2` + scopes for `@Scopes` tools). Default `false` |
 | `resilience` | `object` | No | Global resilience defaults |
 | `resilience.timeout` | `number` | No | Global timeout in ms |
 | `resilience.rateLimit` | `RateLimitConfig` | No | Global rate limit config |
@@ -125,8 +127,42 @@ export class AppModule {}
 | `imports` | `any[]` | No | Modules to import for dependency injection |
 | `transport` | `McpTransportType \| McpTransportType[]` | Yes | Transports to enable |
 | `transportOptions` | `TransportOptions` | No | Per-transport configuration |
-| `useFactory` | `(...args: any[]) => McpModuleOptions \| Promise<McpModuleOptions>` | Yes | Factory function |
+| `useFactory` | `(...args: any[]) => McpModuleOptions \| Promise<McpModuleOptions>` | One of | Factory function |
+| `useClass` | `Type<McpOptionsFactory>` | One of | Class instantiated by the module; its `createMcpOptions()` builds the options |
+| `useExisting` | `Type<McpOptionsFactory>` | One of | Existing provider (from `imports`) implementing `McpOptionsFactory` |
 | `inject` | `any[]` | No | Injection tokens for the factory |
+| `extraProviders` | `Provider[]` | No | Additional providers registered alongside the module's own |
+
+One of `useFactory`, `useClass`, or `useExisting` is required. With
+`useClass`/`useExisting`, implement the `McpOptionsFactory` interface:
+
+```typescript
+import type { McpModuleOptions, McpOptionsFactory } from '@nest-mcp/common';
+
+@Injectable()
+class McpConfig implements McpOptionsFactory {
+  constructor(private readonly config: ConfigService) {}
+
+  createMcpOptions(): McpModuleOptions {
+    return {
+      name: this.config.get('MCP_SERVER_NAME', 'my-server'),
+      version: '1.0.0',
+      transport: McpTransportType.STREAMABLE_HTTP,
+    };
+  }
+}
+
+McpModule.forRootAsync({
+  imports: [ConfigModule],
+  transport: McpTransportType.STREAMABLE_HTTP,
+  useClass: McpConfig,
+});
+```
+
+Note: `transport` and the controller-shaping parts of `transportOptions`
+(endpoint, oauth gate, controller guards/decorators) are read statically from
+the async options object — controllers are created at module-definition time,
+before any factory runs.
 
 ## McpModule.forFeature
 
@@ -198,8 +234,26 @@ Both `forRoot` and `forRootAsync` register the module as global, so you do not n
 - `ResourceSubscriptionManager`
 - `TaskManager`
 
+## Logging
+
+Internal module logging follows standard NestJS conventions:
+
+- **HTTP transports** (Streamable HTTP, SSE): control verbosity at bootstrap
+  with `app.useLogger(['error', 'warn'])` or any custom `LoggerService` —
+  this governs every `@nest-mcp/server` internal logger along with the rest
+  of your app.
+- **STDIO**: stdout belongs to the JSON-RPC protocol, so logs must go to
+  stderr. `bootstrapStdioApp()` installs a stderr logger automatically and
+  honors the `logging` module option (`LogLevel[]` to filter, `false` to
+  silence) as its fallback when `StdioBootstrapOptions.logLevels` is not set.
+
+Messages sent to the **client** via `ctx.log.*` are independent of the above:
+they are `notifications/message` MCP notifications, filtered per session by
+the level the client sets with `logging/setLevel`.
+
 ## See Also
 
 - [Getting Started](./getting-started.md) -- Minimal working example
+- [Dependency Injection](./dependency-injection.md) -- Provider scopes, `REQUEST` injection
 - [Transports](./transports.md) -- Transport-specific configuration
 - [Resilience](./resilience.md) -- Resilience configuration details

--- a/packages/common/src/interfaces/mcp-auth.interface.ts
+++ b/packages/common/src/interfaces/mcp-auth.interface.ts
@@ -25,6 +25,14 @@ export interface McpAuthConfig {
   allowUnauthenticatedAccess?: boolean;
 }
 
+/**
+ * Per-tool auth requirement advertised to clients in `tools/list` `_meta`
+ * (`_meta.securitySchemes`). Not yet part of the MCP spec — mirrors the
+ * `securitySchemes` draft shape also emitted by other MCP server libraries
+ * so clients can discover auth requirements before calling a tool.
+ */
+export type McpSecurityScheme = { type: 'noauth' } | { type: 'oauth2'; scopes?: string[] };
+
 export interface AuthorizableItem {
   name: string;
   isPublic?: boolean;

--- a/packages/common/src/interfaces/mcp-options.interface.ts
+++ b/packages/common/src/interfaces/mcp-options.interface.ts
@@ -27,6 +27,13 @@ export interface McpModuleOptions {
   title?: string;
   version: string;
   description?: string;
+  /**
+   * Guidance for the LLM, returned verbatim on `initialize` as the MCP
+   * `instructions` field. Distinct from `description` (human-facing server
+   * metadata). When omitted, `description` is used as a fallback for
+   * backwards compatibility.
+   */
+  instructions?: string;
   /** URL of the website associated with this server. */
   websiteUrl?: string;
   /** Icons representing this server, sent in MCP `Implementation`. */
@@ -46,6 +53,13 @@ export interface McpModuleOptions {
   // Auth
   guards?: McpGuardClass[];
   allowUnauthenticatedAccess?: boolean;
+  /**
+   * When true, each `tools/list` entry advertises its auth requirements in
+   * `_meta.securitySchemes` (`noauth` for `@Public` tools, `oauth2` with the
+   * tool's `@Scopes`). Lets clients discover per-tool auth needs before
+   * calling. Default false.
+   */
+  advertiseSecuritySchemes?: boolean;
   /**
    * When true, `tools/list`, `resources/list`, and `prompts/list` only return
    * items whose required scopes are covered by the caller's token scopes.
@@ -112,13 +126,35 @@ export interface McpModuleOptions {
   exposure?: ExposureStrategy | ExposureStrategyResolver;
 }
 
+/**
+ * Options-factory contract for `McpModule.forRootAsync({ useClass | useExisting })`,
+ * mirroring the standard NestJS async-module convention.
+ */
+export interface McpOptionsFactory {
+  createMcpOptions(): McpModuleOptions | Promise<McpModuleOptions>;
+}
+
 export interface McpModuleAsyncOptions {
   // biome-ignore lint/suspicious/noExplicitAny: NestJS DynamicModule requires broad module types
   imports?: any[];
   transport: McpTransportType | McpTransportType[];
   transportOptions?: TransportOptions;
+  /** Build options from injected dependencies. One of `useFactory` / `useClass` / `useExisting` is required. */
   // biome-ignore lint/suspicious/noExplicitAny: NestJS factory pattern requires broad parameter types
-  useFactory: (...args: any[]) => McpModuleOptions | Promise<McpModuleOptions>;
+  useFactory?: (...args: any[]) => McpModuleOptions | Promise<McpModuleOptions>;
+  /** Instantiate this class (registered as a provider) and call `createMcpOptions()`. */
+  useClass?: new (
+    // biome-ignore lint/suspicious/noExplicitAny: NestJS DI constructors have broad parameter types
+    ...args: any[]
+  ) => McpOptionsFactory;
+  /** Reuse an existing provider implementing `McpOptionsFactory`. */
+  useExisting?: new (
+    // biome-ignore lint/suspicious/noExplicitAny: NestJS DI constructors have broad parameter types
+    ...args: any[]
+  ) => McpOptionsFactory;
   // biome-ignore lint/suspicious/noExplicitAny: NestJS injection tokens have broad types
   inject?: any[];
+  /** Additional providers registered alongside the module's own (e.g. deps of `useFactory`). */
+  // biome-ignore lint/suspicious/noExplicitAny: NestJS Provider type lives in @nestjs/common
+  extraProviders?: any[];
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,6 +47,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
+    "test:e2e": "vitest run -c vitest.e2e.config.ts",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",
@@ -75,11 +76,13 @@
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/testing": "^11.0.0",
+    "@swc/core": "^1.15.41",
     "express": "^4.21.0",
     "jose": "^6.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
     "typescript": "^5.7.0",
+    "unplugin-swc": "^1.5.9",
     "vitest": "^2.1.0",
     "zod": "^4.0.0"
   }

--- a/packages/server/src/discovery/registry.service.spec.ts
+++ b/packages/server/src/discovery/registry.service.spec.ts
@@ -903,4 +903,24 @@ describe('McpRegistryService', () => {
       );
     });
   });
+
+  describe('registerProviderClass', () => {
+    it('registers decorated methods bound to the class instead of an instance', () => {
+      const reg = new McpRegistryService();
+      reg.registerProviderClass(TestTools);
+
+      const tool = reg.getTool('myTool');
+      expect(tool).toBeDefined();
+      expect(tool?.instance).toBeUndefined();
+      expect(tool?.scopedTarget).toBe(TestTools);
+    });
+
+    it('ignores values that are not classes', () => {
+      const reg = new McpRegistryService();
+      reg.registerProviderClass(undefined as unknown as new () => unknown);
+      reg.registerProviderClass({} as unknown as new () => unknown);
+
+      expect(reg.getAllTools()).toHaveLength(0);
+    });
+  });
 });

--- a/packages/server/src/discovery/registry.service.ts
+++ b/packages/server/src/discovery/registry.service.ts
@@ -27,6 +27,7 @@ import {
   MCP_TOOL_METADATA,
 } from '@nest-mcp/common';
 import { Injectable, Logger } from '@nestjs/common';
+import type { Type } from '@nestjs/common';
 import type { CompletionMetadata } from '../decorators/completion.decorator';
 
 /**
@@ -41,27 +42,29 @@ export interface TaskHandlerConfig {
   getTaskPayload(taskId: string): Promise<GetTaskPayloadResult>;
 }
 
-export interface RegisteredTool extends ToolMetadata {
-  instance: Record<string, unknown>;
+/**
+ * How a registered capability binds to its provider. Singleton providers are
+ * captured as a live `instance` at scan time; request/transient-scoped
+ * providers have no boot-time instance, so the provider class is kept as
+ * `scopedTarget` and resolved per call by the executor (`ModuleRef.resolve`).
+ */
+export interface ProviderBinding {
+  instance?: Record<string, unknown>;
+  scopedTarget?: Type<unknown>;
 }
 
-export interface RegisteredResource extends ResourceMetadata {
-  instance: Record<string, unknown>;
-}
+export interface RegisteredTool extends ToolMetadata, ProviderBinding {}
 
-export interface RegisteredResourceTemplate extends ResourceTemplateMetadata {
-  instance: Record<string, unknown>;
-}
+export interface RegisteredResource extends ResourceMetadata, ProviderBinding {}
 
-export interface RegisteredPrompt extends PromptMetadata {
-  instance: Record<string, unknown>;
-}
+export interface RegisteredResourceTemplate extends ResourceTemplateMetadata, ProviderBinding {}
 
-export interface RegisteredCompletion {
+export interface RegisteredPrompt extends PromptMetadata, ProviderBinding {}
+
+export interface RegisteredCompletion extends ProviderBinding {
   refType: 'ref/prompt' | 'ref/resource';
   refName: string;
   methodName: string;
-  instance: Record<string, unknown>;
 }
 
 @Injectable()
@@ -120,22 +123,37 @@ export class McpRegistryService {
   registerProvider(instance: unknown): void {
     if (!instance || !(instance as Record<string, unknown>).constructor) return;
 
-    const prototype = Object.getPrototypeOf(instance);
+    this.scanPrototype(Object.getPrototypeOf(instance), {
+      instance: instance as Record<string, unknown>,
+    });
+  }
+
+  /**
+   * Register a request/transient-scoped provider class. No instance exists at
+   * boot, so capabilities are bound to the class and resolved per call by the
+   * executor via `ModuleRef.resolve`.
+   */
+  registerProviderClass(target: Type<unknown>): void {
+    if (typeof target !== 'function' || !target.prototype) return;
+    this.scanPrototype(target.prototype, { scopedTarget: target });
+  }
+
+  private scanPrototype(prototype: Record<string, unknown>, binding: ProviderBinding): void {
     const methodNames = Object.getOwnPropertyNames(prototype).filter(
       (name) => name !== 'constructor' && typeof prototype[name] === 'function',
     );
 
     for (const methodName of methodNames) {
-      this.scanToolMetadata(instance as Record<string, unknown>, prototype, methodName);
-      this.scanResourceMetadata(instance as Record<string, unknown>, prototype, methodName);
-      this.scanResourceTemplateMetadata(instance as Record<string, unknown>, prototype, methodName);
-      this.scanPromptMetadata(instance as Record<string, unknown>, prototype, methodName);
-      this.scanCompletionMetadata(instance as Record<string, unknown>, prototype, methodName);
+      this.scanToolMetadata(binding, prototype, methodName);
+      this.scanResourceMetadata(binding, prototype, methodName);
+      this.scanResourceTemplateMetadata(binding, prototype, methodName);
+      this.scanPromptMetadata(binding, prototype, methodName);
+      this.scanCompletionMetadata(binding, prototype, methodName);
     }
   }
 
   private scanToolMetadata(
-    instance: Record<string, unknown>,
+    binding: ProviderBinding,
     prototype: object,
     methodName: string,
   ): void {
@@ -149,7 +167,7 @@ export class McpRegistryService {
     // Merge auth/resilience decorators
     const enriched: RegisteredTool = {
       ...metadata,
-      instance,
+      ...binding,
       isPublic: Reflect.getMetadata(MCP_PUBLIC_METADATA, prototype, methodName) ?? false,
       requiredScopes: Reflect.getMetadata(MCP_SCOPES_METADATA, prototype, methodName),
       requiredRoles: Reflect.getMetadata(MCP_ROLES_METADATA, prototype, methodName),
@@ -171,7 +189,7 @@ export class McpRegistryService {
   }
 
   private scanResourceMetadata(
-    instance: Record<string, unknown>,
+    binding: ProviderBinding,
     prototype: object,
     methodName: string,
   ): void {
@@ -182,14 +200,14 @@ export class McpRegistryService {
     );
     if (!metadata) return;
 
-    const registered: RegisteredResource = { ...metadata, instance };
+    const registered: RegisteredResource = { ...metadata, ...binding };
     this.warnIfMissingDescription('Resource', registered.name, registered.description);
     this.resources.set(registered.uri, registered);
     this.logger.log(`Registered resource: ${registered.uri}`);
   }
 
   private scanResourceTemplateMetadata(
-    instance: Record<string, unknown>,
+    binding: ProviderBinding,
     prototype: object,
     methodName: string,
   ): void {
@@ -200,14 +218,14 @@ export class McpRegistryService {
     );
     if (!metadata) return;
 
-    const registered: RegisteredResourceTemplate = { ...metadata, instance };
+    const registered: RegisteredResourceTemplate = { ...metadata, ...binding };
     this.warnIfMissingDescription('ResourceTemplate', registered.name, registered.description);
     this.resourceTemplates.set(registered.uriTemplate, registered);
     this.logger.log(`Registered resource template: ${registered.uriTemplate}`);
   }
 
   private scanPromptMetadata(
-    instance: Record<string, unknown>,
+    binding: ProviderBinding,
     prototype: object,
     methodName: string,
   ): void {
@@ -218,14 +236,14 @@ export class McpRegistryService {
     );
     if (!metadata) return;
 
-    const registered: RegisteredPrompt = { ...metadata, instance };
+    const registered: RegisteredPrompt = { ...metadata, ...binding };
     this.warnIfMissingDescription('Prompt', registered.name, registered.description);
     this.prompts.set(registered.name, registered);
     this.logger.log(`Registered prompt: ${registered.name}`);
   }
 
   private scanCompletionMetadata(
-    instance: Record<string, unknown>,
+    binding: ProviderBinding,
     prototype: object,
     methodName: string,
   ): void {
@@ -241,7 +259,7 @@ export class McpRegistryService {
       refType: metadata.refType,
       refName: metadata.refName,
       methodName: metadata.methodName,
-      instance,
+      ...binding,
     };
 
     this.completionHandlers.set(key, registered);

--- a/packages/server/src/discovery/scanner.service.spec.ts
+++ b/packages/server/src/discovery/scanner.service.spec.ts
@@ -51,16 +51,21 @@ class PlainClass {
 
 // --- Helpers ---
 
+interface WrapperMock {
+  instance: unknown;
+  metatype?: unknown;
+}
+
 function makeModulesContainer(
   modules: Array<{
-    providers: Array<{ key: string | symbol; instance: unknown }>;
+    providers: Array<{ key: string | symbol; instance: unknown; metatype?: unknown }>;
   }>,
-): Map<string, { providers: Map<string | symbol, { instance: unknown }> }> {
-  const container = new Map<string, { providers: Map<string | symbol, { instance: unknown }> }>();
+): Map<string, { providers: Map<string | symbol, WrapperMock> }> {
+  const container = new Map<string, { providers: Map<string | symbol, WrapperMock> }>();
   for (let i = 0; i < modules.length; i++) {
-    const providerMap = new Map<string | symbol, { instance: unknown }>();
+    const providerMap = new Map<string | symbol, WrapperMock>();
     for (const p of modules[i].providers) {
-      providerMap.set(p.key, { instance: p.instance });
+      providerMap.set(p.key, { instance: p.instance, metatype: p.metatype });
     }
     container.set(`module-${i}`, { providers: providerMap });
   }
@@ -284,6 +289,50 @@ describe('McpScannerService', () => {
       scanner.onModuleInit();
 
       expect(registry.getAllResources()).toHaveLength(0);
+    });
+  });
+
+  describe('request-scoped providers (no boot-time instance)', () => {
+    it('registers a decorated provider class via its metatype when no instance exists', () => {
+      const container = makeModulesContainer([
+        { providers: [{ key: WeatherTool, instance: undefined, metatype: WeatherTool }] },
+      ]);
+      const registry = new McpRegistryService();
+      const scanner = makeScanner(container, 'any-server', registry);
+      scanner.onModuleInit();
+
+      const tool = registry.getTool('getWeather');
+      expect(tool).toBeDefined();
+      expect(tool?.instance).toBeUndefined();
+      expect(tool?.scopedTarget).toBe(WeatherTool);
+    });
+
+    it('ignores instance-less wrappers whose metatype has no MCP decorators', () => {
+      const container = makeModulesContainer([
+        { providers: [{ key: PlainClass, instance: undefined, metatype: PlainClass }] },
+      ]);
+      const registry = new McpRegistryService();
+      const scanner = makeScanner(container, 'any-server', registry);
+      scanner.onModuleInit();
+
+      expect(registry.getAllTools()).toHaveLength(0);
+    });
+
+    it('applies forFeature server targeting to scoped provider classes', () => {
+      const registration = { serverName: 'other-server', providerTokens: [AdminTool] };
+      const container = makeModulesContainer([
+        {
+          providers: [
+            { key: AdminTool, instance: undefined, metatype: AdminTool },
+            { key: `${MCP_FEATURE_REGISTRATION}_3`, instance: registration },
+          ],
+        },
+      ]);
+      const registry = new McpRegistryService();
+      const scanner = makeScanner(container, 'my-server', registry);
+      scanner.onModuleInit();
+
+      expect(registry.getAllTools()).toHaveLength(0);
     });
   });
 });

--- a/packages/server/src/discovery/scanner.service.ts
+++ b/packages/server/src/discovery/scanner.service.ts
@@ -35,16 +35,32 @@ export class McpScannerService implements OnModuleInit {
     for (const [, moduleRef] of this.modulesContainer) {
       for (const [, wrapper] of moduleRef.providers) {
         const instance = wrapper?.instance;
-        if (!instance || !instance.constructor) continue;
+        const metatype = wrapper?.metatype as (new (...args: unknown[]) => unknown) | undefined;
+        const constructor = instance?.constructor ?? metatype;
+        if (!constructor) continue;
 
         // If this provider is explicitly targeted at a server, filter by current server
-        const targetedServers = serverTargetedTokens.get(instance.constructor as InjectionToken);
+        const targetedServers = serverTargetedTokens.get(constructor as InjectionToken);
         if (targetedServers && !targetedServers.includes(this.options.name)) {
           continue;
         }
 
-        if (this.hasAnyMcpDecorator(instance)) {
-          this.registry.registerProvider(instance);
+        // Request/transient-scoped wrappers expose a never-constructed shell
+        // object as `instance` (Nest creates it via Object.create for lazy
+        // instantiation), so instance truthiness alone cannot distinguish
+        // scoped providers from singletons.
+        const isStatic = this.isDependencyTreeStatic(wrapper) && Boolean(instance?.constructor);
+
+        if (isStatic && instance?.constructor) {
+          if (this.hasAnyMcpDecorator(Object.getPrototypeOf(instance))) {
+            this.registry.registerProvider(instance);
+          }
+        } else if (typeof metatype === 'function' && metatype.prototype) {
+          // Scoped providers have no usable boot-time instance — register the
+          // class so the executor resolves a fresh one per call.
+          if (this.hasAnyMcpDecorator(metatype.prototype)) {
+            this.registry.registerProviderClass(metatype);
+          }
         }
       }
     }
@@ -81,8 +97,19 @@ export class McpScannerService implements OnModuleInit {
     return map;
   }
 
-  private hasAnyMcpDecorator(instance: unknown): boolean {
-    const prototype = Object.getPrototypeOf(instance);
+  /**
+   * True when the wrapper's whole dependency tree is singleton-scoped (a
+   * request/transient provider anywhere in the tree makes it per-request).
+   * Falls back to `true` for wrapper mocks that lack the Nest API.
+   */
+  private isDependencyTreeStatic(wrapper: unknown): boolean {
+    const candidate = wrapper as { isDependencyTreeStatic?: () => boolean };
+    return typeof candidate.isDependencyTreeStatic === 'function'
+      ? candidate.isDependencyTreeStatic()
+      : true;
+  }
+
+  private hasAnyMcpDecorator(prototype: object): boolean {
     const methodNames = Object.getOwnPropertyNames(prototype).filter(
       (name) => name !== 'constructor',
     );

--- a/packages/server/src/execution/context.factory.spec.ts
+++ b/packages/server/src/execution/context.factory.spec.ts
@@ -201,11 +201,14 @@ describe('McpContextFactory', () => {
 
       ctx.log.debug('test message');
 
-      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith({
-        level: 'debug',
-        logger: 'MCP:sess-abc',
-        data: 'test message',
-      });
+      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith(
+        {
+          level: 'debug',
+          logger: 'MCP:sess-abc',
+          data: 'test message',
+        },
+        undefined,
+      );
     });
 
     it('calls sendLoggingMessage on info', () => {
@@ -220,11 +223,14 @@ describe('McpContextFactory', () => {
 
       ctx.log.info('info message');
 
-      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith({
-        level: 'info',
-        logger: 'MCP:sess-abc',
-        data: 'info message',
-      });
+      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith(
+        {
+          level: 'info',
+          logger: 'MCP:sess-abc',
+          data: 'info message',
+        },
+        undefined,
+      );
     });
 
     it('maps warn to MCP warning level', () => {
@@ -239,11 +245,14 @@ describe('McpContextFactory', () => {
 
       ctx.log.warn('warn message');
 
-      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith({
-        level: 'warning',
-        logger: 'MCP:sess-abc',
-        data: 'warn message',
-      });
+      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith(
+        {
+          level: 'warning',
+          logger: 'MCP:sess-abc',
+          data: 'warn message',
+        },
+        undefined,
+      );
     });
 
     it('calls sendLoggingMessage on error', () => {
@@ -258,11 +267,14 @@ describe('McpContextFactory', () => {
 
       ctx.log.error('error message');
 
-      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith({
-        level: 'error',
-        logger: 'MCP:sess-abc',
-        data: 'error message',
-      });
+      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith(
+        {
+          level: 'error',
+          logger: 'MCP:sess-abc',
+          data: 'error message',
+        },
+        undefined,
+      );
     });
 
     it('includes data in sendLoggingMessage when provided', () => {
@@ -277,11 +289,33 @@ describe('McpContextFactory', () => {
 
       ctx.log.info('with data', { key: 'value' });
 
-      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith({
-        level: 'info',
-        logger: 'MCP:sess-abc',
-        data: { message: 'with data', key: 'value' },
+      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith(
+        {
+          level: 'info',
+          logger: 'MCP:sess-abc',
+          data: { message: 'with data', key: 'value' },
+        },
+        undefined,
+      );
+    });
+
+    it('passes the transport session id so logging/setLevel filtering applies', () => {
+      const mockServer = {
+        server: { transport: { sessionId: 'transport-sess-1' } },
+        sendLoggingMessage: vi.fn().mockResolvedValue(undefined),
+      };
+      const ctx = factory.createContext({
+        sessionId: 'sess-abcd1234',
+        transport: McpTransportType.STREAMABLE_HTTP,
+        mcpServer: mockServer as never,
       });
+
+      ctx.log.info('routed message');
+
+      expect(mockServer.sendLoggingMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ level: 'info' }),
+        'transport-sess-1',
+      );
     });
 
     it('swallows rejected sendLoggingMessage promise', () => {

--- a/packages/server/src/execution/context.factory.ts
+++ b/packages/server/src/execution/context.factory.ts
@@ -25,6 +25,10 @@ export class McpContextFactory {
     const logger = new Logger(`MCP:${options.sessionId.slice(0, 8)}`);
     const loggerName = `MCP:${options.sessionId.slice(0, 8)}`;
     const server = options.mcpServer;
+    // `logging/setLevel` stores the client's level keyed by the TRANSPORT
+    // session id (SDK `Server`). Pass the same key on every message or the
+    // SDK's per-session level filtering never applies.
+    const transportSessionId = () => server?.server?.transport?.sessionId;
 
     return {
       sessionId: options.sessionId,
@@ -57,41 +61,53 @@ export class McpContextFactory {
         debug: (message, data) => {
           logger.debug(message, data);
           server
-            ?.sendLoggingMessage({
-              level: 'debug',
-              logger: loggerName,
-              data: data ? { message, ...data } : message,
-            })
+            ?.sendLoggingMessage(
+              {
+                level: 'debug',
+                logger: loggerName,
+                data: data ? { message, ...data } : message,
+              },
+              transportSessionId(),
+            )
             .catch(() => {});
         },
         info: (message, data) => {
           logger.log(message, data);
           server
-            ?.sendLoggingMessage({
-              level: 'info',
-              logger: loggerName,
-              data: data ? { message, ...data } : message,
-            })
+            ?.sendLoggingMessage(
+              {
+                level: 'info',
+                logger: loggerName,
+                data: data ? { message, ...data } : message,
+              },
+              transportSessionId(),
+            )
             .catch(() => {});
         },
         warn: (message, data) => {
           logger.warn(message, data);
           server
-            ?.sendLoggingMessage({
-              level: 'warning',
-              logger: loggerName,
-              data: data ? { message, ...data } : message,
-            })
+            ?.sendLoggingMessage(
+              {
+                level: 'warning',
+                logger: loggerName,
+                data: data ? { message, ...data } : message,
+              },
+              transportSessionId(),
+            )
             .catch(() => {});
         },
         error: (message, data) => {
           logger.error(message, data);
           server
-            ?.sendLoggingMessage({
-              level: 'error',
-              logger: loggerName,
-              data: data ? { message, ...data } : message,
-            })
+            ?.sendLoggingMessage(
+              {
+                level: 'error',
+                logger: loggerName,
+                data: data ? { message, ...data } : message,
+              },
+              transportSessionId(),
+            )
             .catch(() => {});
         },
       },

--- a/packages/server/src/execution/executor.service.spec.ts
+++ b/packages/server/src/execution/executor.service.spec.ts
@@ -992,4 +992,152 @@ describe('McpExecutorService', () => {
       expect(third.nextCursor).toBeUndefined();
     });
   });
+
+  // --- request-scoped provider resolution ---
+
+  describe('scoped provider resolution', () => {
+    class ScopedTool {
+      greet(args: Record<string, unknown>) {
+        return `hello ${args.name}`;
+      }
+    }
+
+    function makeScopedExecutor(moduleRef?: {
+      resolve: ReturnType<typeof vi.fn>;
+      registerRequestByContextId: ReturnType<typeof vi.fn>;
+    }) {
+      const exec = new McpExecutorService(
+        registry,
+        new McpExceptionFilterRunner(new Reflector()),
+        defaultOptions,
+        moduleRef as unknown as import('@nestjs/core').ModuleRef,
+      );
+      registry.registerTool({
+        name: 'scoped-greet',
+        description: 'Scoped tool',
+        methodName: 'greet',
+        target: ScopedTool,
+        scopedTarget: ScopedTool,
+      } as RegisteredTool);
+      return exec;
+    }
+
+    it('resolves a fresh instance per call via ModuleRef', async () => {
+      const moduleRef = {
+        resolve: vi.fn(async () => new ScopedTool()),
+        registerRequestByContextId: vi.fn(),
+      };
+      const exec = makeScopedExecutor(moduleRef);
+
+      const result = await exec.callTool('scoped-greet', { name: 'ada' }, ctx);
+      expect(result.content).toEqual([{ type: 'text', text: 'hello ada' }]);
+      expect(moduleRef.resolve).toHaveBeenCalledWith(ScopedTool, expect.anything(), {
+        strict: false,
+      });
+
+      await exec.callTool('scoped-greet', { name: 'bob' }, ctx);
+      expect(moduleRef.resolve).toHaveBeenCalledTimes(2);
+    });
+
+    it('registers the request on the context id so @Inject(REQUEST) works', async () => {
+      const moduleRef = {
+        resolve: vi.fn(async () => new ScopedTool()),
+        registerRequestByContextId: vi.fn(),
+      };
+      const exec = makeScopedExecutor(moduleRef);
+      const request = { headers: { 'x-tenant': 'acme' } };
+
+      await exec.callTool('scoped-greet', { name: 'ada' }, mockMcpContext({ request }));
+      expect(moduleRef.registerRequestByContextId).toHaveBeenCalledWith(
+        request,
+        expect.anything(),
+      );
+    });
+
+    it('does not register a request when the context has none', async () => {
+      const moduleRef = {
+        resolve: vi.fn(async () => new ScopedTool()),
+        registerRequestByContextId: vi.fn(),
+      };
+      const exec = makeScopedExecutor(moduleRef);
+
+      await exec.callTool('scoped-greet', { name: 'ada' }, ctx);
+      expect(moduleRef.registerRequestByContextId).not.toHaveBeenCalled();
+    });
+
+    it('throws ToolExecutionError when a scoped tool has no ModuleRef available', async () => {
+      const exec = makeScopedExecutor(undefined);
+
+      await expect(exec.callTool('scoped-greet', { name: 'ada' }, ctx)).rejects.toThrow(
+        ToolExecutionError,
+      );
+    });
+  });
+
+  // --- securitySchemes advertisement ---
+
+  describe('securitySchemes advertisement', () => {
+    function makeAdvertisingExecutor(options: Partial<McpModuleOptions> = {}) {
+      return new McpExecutorService(registry, new McpExceptionFilterRunner(new Reflector()), {
+        ...defaultOptions,
+        advertiseSecuritySchemes: true,
+        ...options,
+      });
+    }
+
+    function registerTool(extra: Partial<RegisteredTool> = {}) {
+      registry.registerTool({
+        name: 'a-tool',
+        description: 'A tool',
+        methodName: 'run',
+        target: Object,
+        instance: { run: vi.fn() },
+        ...extra,
+      } as RegisteredTool);
+    }
+
+    it('does not emit securitySchemes by default', async () => {
+      registerTool({ requiredScopes: ['read:data'] });
+      const result = await executor.listTools();
+      expect(result.items[0]._meta).toBeUndefined();
+    });
+
+    it('emits oauth2 with scopes for tools with @Scopes metadata', async () => {
+      registerTool({ requiredScopes: ['read:data', 'write:data'] });
+      const result = await makeAdvertisingExecutor().listTools();
+      expect(result.items[0]._meta).toEqual({
+        securitySchemes: [{ type: 'oauth2', scopes: ['read:data', 'write:data'] }],
+      });
+    });
+
+    it('emits noauth for public tools', async () => {
+      registerTool({ isPublic: true });
+      const result = await makeAdvertisingExecutor().listTools();
+      expect(result.items[0]._meta).toEqual({ securitySchemes: [{ type: 'noauth' }] });
+    });
+
+    it('emits bare oauth2 for unmarked tools when the module gates requests', async () => {
+      registerTool();
+      const exec = makeAdvertisingExecutor({
+        transportOptions: { streamableHttp: { oauth: { enabled: true } } },
+      });
+      const result = await exec.listTools();
+      expect(result.items[0]._meta).toEqual({ securitySchemes: [{ type: 'oauth2' }] });
+    });
+
+    it('emits noauth for unmarked tools when nothing gates requests', async () => {
+      registerTool();
+      const result = await makeAdvertisingExecutor().listTools();
+      expect(result.items[0]._meta).toEqual({ securitySchemes: [{ type: 'noauth' }] });
+    });
+
+    it('merges securitySchemes into existing _meta', async () => {
+      registerTool({ isPublic: true, _meta: { vendor: 'x' } });
+      const result = await makeAdvertisingExecutor().listTools();
+      expect(result.items[0]._meta).toEqual({
+        vendor: 'x',
+        securitySchemes: [{ type: 'noauth' }],
+      });
+    });
+  });
 });

--- a/packages/server/src/execution/executor.service.ts
+++ b/packages/server/src/execution/executor.service.ts
@@ -6,6 +6,7 @@ import {
   McpError,
   type McpExecutionContext,
   type McpModuleOptions,
+  type McpSecurityScheme,
   type PaginatedResult,
   type PromptGetResult,
   type ResourceReadResult,
@@ -18,10 +19,11 @@ import {
   paginate,
   zodToJsonSchema,
 } from '@nest-mcp/common';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ContextIdFactory, ModuleRef } from '@nestjs/core';
 import { ZodEnum, ZodObject, type ZodType } from 'zod';
 import { McpRegistryService } from '../discovery/registry.service';
-import type { RegisteredTool } from '../discovery/registry.service';
+import type { ProviderBinding, RegisteredTool } from '../discovery/registry.service';
 import { isPlainRecord } from '../utils/coerce';
 import { type FilterTarget, McpExceptionFilterRunner } from './exception-filter.runner';
 
@@ -71,13 +73,49 @@ function extractStructuredCandidate(result: unknown): Record<string, unknown> | 
 export class McpExecutorService {
   private readonly logger = new Logger(McpExecutorService.name);
   private readonly pageSize: number | undefined;
+  private readonly advertiseSecuritySchemes: boolean;
+  private readonly moduleRequiresAuth: boolean;
 
   constructor(
     private readonly registry: McpRegistryService,
     private readonly exceptionFilters: McpExceptionFilterRunner,
     @Inject(MCP_OPTIONS) options: McpModuleOptions,
+    @Optional() private readonly moduleRef?: ModuleRef,
   ) {
     this.pageSize = options.pagination?.defaultPageSize;
+    this.advertiseSecuritySchemes = options.advertiseSecuritySchemes ?? false;
+    this.moduleRequiresAuth =
+      Boolean(options.guards?.length) ||
+      Boolean(options.transportOptions?.streamableHttp?.oauth?.enabled) ||
+      Boolean(options.transportOptions?.sse?.oauth?.enabled);
+  }
+
+  /**
+   * Resolve the provider object to invoke a capability on. Singleton
+   * providers carry a live `instance` from scan time; request/transient-scoped
+   * providers carry a `scopedTarget` class resolved fresh per call. When the
+   * execution context has an HTTP request, it is registered on the context id
+   * so `@Inject(REQUEST)` works inside scoped providers.
+   */
+  private async resolveBinding(
+    binding: ProviderBinding,
+    label: string,
+    ctx?: McpExecutionContext,
+  ): Promise<Record<string, unknown>> {
+    if (binding.instance) return binding.instance;
+    if (binding.scopedTarget && this.moduleRef) {
+      const contextId = ContextIdFactory.create();
+      if (ctx?.request) {
+        this.moduleRef.registerRequestByContextId(ctx.request, contextId);
+      }
+      return this.moduleRef.resolve(binding.scopedTarget, contextId, { strict: false });
+    }
+    throw new ToolExecutionError(
+      label,
+      binding.scopedTarget
+        ? `Cannot resolve request-scoped provider '${binding.scopedTarget.name}' without a ModuleRef`
+        : `No provider bound for '${label}'`,
+    );
   }
 
   // ---- Tools ----
@@ -97,6 +135,9 @@ export class McpExecutorService {
       const outputSchema = tool.outputSchema
         ? (zodToJsonSchema(tool.outputSchema) as Record<string, unknown>)
         : tool.rawOutputSchema;
+      const meta = this.advertiseSecuritySchemes
+        ? { ...(tool._meta ?? {}), securitySchemes: this.buildSecuritySchemes(tool) }
+        : tool._meta;
       return {
         name: tool.name,
         ...(tool.title != null ? { title: tool.title } : {}),
@@ -106,9 +147,27 @@ export class McpExecutorService {
         ...(tool.annotations ? { annotations: tool.annotations } : {}),
         ...(tool.icons ? { icons: tool.icons } : {}),
         ...(tool.execution ? { execution: tool.execution } : {}),
-        ...(tool._meta ? { _meta: tool._meta } : {}),
+        ...(meta ? { _meta: meta } : {}),
       };
     });
+  }
+
+  /**
+   * Derive the advertised auth requirements for a tool from its `@Public` /
+   * `@Scopes` metadata. `oauth2` without scopes means "any authenticated
+   * caller" and is emitted when the module itself gates requests (guards or
+   * an OAuth-enabled transport) and the tool isn't public.
+   */
+  private buildSecuritySchemes(tool: RegisteredTool): McpSecurityScheme[] {
+    const schemes: McpSecurityScheme[] = [];
+    if (tool.isPublic) schemes.push({ type: 'noauth' });
+    if (tool.requiredScopes?.length) {
+      schemes.push({ type: 'oauth2', scopes: tool.requiredScopes });
+    } else if (this.moduleRequiresAuth && !tool.isPublic) {
+      schemes.push({ type: 'oauth2' });
+    }
+    if (schemes.length === 0) schemes.push({ type: 'noauth' });
+    return schemes;
   }
 
   async listTools(cursor?: string): Promise<PaginatedResult<ToolListEntry>> {
@@ -143,10 +202,11 @@ export class McpExecutorService {
     }
 
     try {
-      const handler = tool.instance[tool.methodName] as
+      const instance = await this.resolveBinding(tool, name, ctx);
+      const handler = instance[tool.methodName] as
         // biome-ignore lint/complexity/noBannedTypes: dynamic method call
         Function;
-      const result = await handler.call(tool.instance, validatedArgs, ctx);
+      const result = await handler.call(instance, validatedArgs, ctx);
       return this.normalizeToolResult(result, tool);
     } catch (error) {
       if (error instanceof ToolExecutionError || error instanceof ValidationError) {
@@ -259,10 +319,11 @@ export class McpExecutorService {
     const resource = this.registry.getResource(uri);
     if (resource) {
       try {
-        const handler = resource.instance[resource.methodName] as
+        const instance = await this.resolveBinding(resource, uri, ctx);
+        const handler = instance[resource.methodName] as
           // biome-ignore lint/complexity/noBannedTypes: dynamic method call
           Function;
-        const result = await handler.call(resource.instance, new URL(uri), ctx);
+        const result = await handler.call(instance, new URL(uri), ctx);
         return this.normalizeResourceResult(result, uri);
       } catch (error) {
         throw this.processCapabilityError(error, resource, ctx);
@@ -274,10 +335,11 @@ export class McpExecutorService {
       const match = matchUriTemplate(template.uriTemplate, uri);
       if (match) {
         try {
-          const handler = template.instance[template.methodName] as
+          const instance = await this.resolveBinding(template, uri, ctx);
+          const handler = instance[template.methodName] as
             // biome-ignore lint/complexity/noBannedTypes: dynamic method call
             Function;
-          const result = await handler.call(template.instance, new URL(uri), match.params, ctx);
+          const result = await handler.call(instance, new URL(uri), match.params, ctx);
           return this.normalizeResourceResult(result, uri);
         } catch (error) {
           throw this.processCapabilityError(error, template, ctx);
@@ -356,10 +418,11 @@ export class McpExecutorService {
 
     let result: unknown;
     try {
-      const handler = prompt.instance[prompt.methodName] as
+      const instance = await this.resolveBinding(prompt, name, ctx);
+      const handler = instance[prompt.methodName] as
         // biome-ignore lint/complexity/noBannedTypes: dynamic method call
         Function;
-      result = await handler.call(prompt.instance, validatedArgs, ctx);
+      result = await handler.call(instance, validatedArgs, ctx);
     } catch (error) {
       throw this.processCapabilityError(error, prompt, ctx);
     }
@@ -378,11 +441,12 @@ export class McpExecutorService {
     const handler = this.registry.getCompletionHandler(request.ref.type, refName);
 
     if (handler) {
-      const fn = handler.instance[handler.methodName] as
+      const instance = await this.resolveBinding(handler, `completion ${refName}`);
+      const fn = instance[handler.methodName] as
         // biome-ignore lint/complexity/noBannedTypes: dynamic method call
         Function;
       const result = await fn.call(
-        handler.instance,
+        instance,
         request.argument.name,
         request.argument.value,
         request.context,

--- a/packages/server/src/mcp.module.spec.ts
+++ b/packages/server/src/mcp.module.spec.ts
@@ -1,8 +1,13 @@
 import 'reflect-metadata';
-import { McpError, type McpModuleOptions, McpTransportType } from '@nest-mcp/common';
+import { MCP_OPTIONS, McpError, type McpModuleOptions, McpTransportType } from '@nest-mcp/common';
 import { describe, expect, it } from 'vitest';
 import { McpBearerGuard } from './auth/guards/mcp-bearer.guard';
-import { MCP_OAUTH_GATE_CHECK, McpModule, createOauthGateCheckProvider } from './mcp.module';
+import {
+  MCP_OAUTH_GATE_CHECK,
+  McpModule,
+  createAsyncOptionsProviders,
+  createOauthGateCheckProvider,
+} from './mcp.module';
 
 describe('McpModule', () => {
   describe('forRoot', () => {
@@ -681,6 +686,87 @@ describe('McpModule', () => {
 
         expect(getToken(mod1)).not.toBe(getToken(mod2));
       });
+    });
+  });
+
+  describe('createAsyncOptionsProviders', () => {
+    const baseOptions: McpModuleOptions = {
+      name: 'async-test',
+      version: '1.0.0',
+      transport: McpTransportType.STDIO,
+    };
+
+    class TestOptionsFactory {
+      createMcpOptions(): McpModuleOptions {
+        return baseOptions;
+      }
+    }
+
+    it('builds a factory provider from useFactory with inject tokens', () => {
+      const useFactory = () => baseOptions;
+      const providers = createAsyncOptionsProviders({
+        transport: McpTransportType.STDIO,
+        useFactory,
+        inject: ['DEP'],
+      });
+
+      expect(providers).toHaveLength(1);
+      expect(providers[0]).toMatchObject({ provide: MCP_OPTIONS, useFactory, inject: ['DEP'] });
+    });
+
+    it('builds providers from useClass: registers the class and delegates to createMcpOptions', async () => {
+      const providers = createAsyncOptionsProviders({
+        transport: McpTransportType.STDIO,
+        useClass: TestOptionsFactory,
+      });
+
+      expect(providers).toHaveLength(2);
+      expect(providers[0]).toMatchObject({
+        provide: TestOptionsFactory,
+        useClass: TestOptionsFactory,
+      });
+      const optionsProvider = providers[1] as {
+        provide: unknown;
+        useFactory: (f: TestOptionsFactory) => McpModuleOptions | Promise<McpModuleOptions>;
+        inject: unknown[];
+      };
+      expect(optionsProvider.provide).toBe(MCP_OPTIONS);
+      expect(optionsProvider.inject).toEqual([TestOptionsFactory]);
+      expect(await optionsProvider.useFactory(new TestOptionsFactory())).toEqual(baseOptions);
+    });
+
+    it('builds a single provider from useExisting without re-registering the class', () => {
+      const providers = createAsyncOptionsProviders({
+        transport: McpTransportType.STDIO,
+        useExisting: TestOptionsFactory,
+      });
+
+      expect(providers).toHaveLength(1);
+      expect(providers[0]).toMatchObject({ provide: MCP_OPTIONS, inject: [TestOptionsFactory] });
+    });
+
+    it('throws when none of useFactory/useClass/useExisting is provided', () => {
+      expect(() =>
+        createAsyncOptionsProviders({ transport: McpTransportType.STDIO }),
+      ).toThrow(McpError);
+    });
+  });
+
+  describe('forRootAsync extraProviders', () => {
+    it('registers extraProviders alongside module providers', () => {
+      const extra = { provide: 'EXTRA_DEP', useValue: 42 };
+      const mod = McpModule.forRootAsync({
+        transport: McpTransportType.STDIO,
+        useFactory: (dep: number) => ({
+          name: `test-${dep}`,
+          version: '1.0',
+          transport: McpTransportType.STDIO,
+        }),
+        inject: ['EXTRA_DEP'],
+        extraProviders: [extra],
+      });
+
+      expect(mod.providers).toContain(extra);
     });
   });
 });

--- a/packages/server/src/mcp.module.ts
+++ b/packages/server/src/mcp.module.ts
@@ -1,4 +1,4 @@
-import type { McpModuleAsyncOptions, McpModuleOptions } from '@nest-mcp/common';
+import type { McpModuleAsyncOptions, McpModuleOptions, McpOptionsFactory } from '@nest-mcp/common';
 import { MCP_OPTIONS, McpError, McpTransportType } from '@nest-mcp/common';
 import {
   type DynamicModule,
@@ -93,6 +93,41 @@ function withBearerGuard(oauthEnabled: boolean | undefined, guards?: unknown[]):
 
 /** Token for the bootstrap oauth-gate consistency check (eagerly instantiated). */
 export const MCP_OAUTH_GATE_CHECK = Symbol('MCP_OAUTH_GATE_CHECK');
+
+/**
+ * Build the MCP_OPTIONS provider(s) for `forRootAsync` from whichever of
+ * `useFactory` / `useClass` / `useExisting` the caller supplied (standard
+ * NestJS async-module convention).
+ *
+ * Exported for tests only.
+ */
+export function createAsyncOptionsProviders(options: McpModuleAsyncOptions): Provider[] {
+  if (options.useFactory) {
+    return [
+      {
+        provide: MCP_OPTIONS,
+        useFactory: options.useFactory,
+        inject: options.inject ?? [],
+      },
+    ];
+  }
+
+  const factoryToken = options.useExisting ?? options.useClass;
+  if (!factoryToken) {
+    throw new McpError(
+      'McpModule.forRootAsync requires one of useFactory, useClass, or useExisting',
+    );
+  }
+
+  return [
+    ...(options.useClass ? [{ provide: options.useClass, useClass: options.useClass }] : []),
+    {
+      provide: MCP_OPTIONS,
+      useFactory: (factory: McpOptionsFactory) => factory.createMcpOptions(),
+      inject: [factoryToken],
+    },
+  ];
+}
 
 /**
  * `McpBearerGuard` is attached to the generated controllers at
@@ -225,11 +260,8 @@ export class McpModule {
   static forRootAsync(options: McpModuleAsyncOptions): DynamicModule {
     const controllers: Type[] = [];
     const providers: Provider[] = [
-      {
-        provide: MCP_OPTIONS,
-        useFactory: options.useFactory,
-        inject: options.inject ?? [],
-      },
+      ...createAsyncOptionsProviders(options),
+      ...(options.extraProviders ?? []),
       McpRegistryService,
       McpScannerService,
       McpExceptionFilterRunner,

--- a/packages/server/src/server/server.factory.spec.ts
+++ b/packages/server/src/server/server.factory.spec.ts
@@ -52,16 +52,40 @@ describe('createMcpServer', () => {
     expect(server).toBeInstanceOf(McpServer);
   });
 
-  it('includes instructions when description is provided', () => {
-    // If description is absent, no throw; if present, it is forwarded.
-    // We verify the factory does not throw in either case.
-    expect(() =>
-      createMcpServer(makeRegistry(), { ...baseOptions, description: 'A helpful server' }),
-    ).not.toThrow();
+  // Pins the SDK Server's private `_instructions` field — the value returned
+  // verbatim on `initialize`.
+  function getInstructions(server: McpServer): string | undefined {
+    return (server.server as unknown as { _instructions?: string })._instructions;
+  }
+
+  it('uses the dedicated instructions option when provided', () => {
+    const server = createMcpServer(makeRegistry(), {
+      ...baseOptions,
+      instructions: 'Use the search tool first.',
+    });
+    expect(getInstructions(server)).toBe('Use the search tool first.');
   });
 
-  it('does not throw when description is absent', () => {
-    expect(() => createMcpServer(makeRegistry(), baseOptions)).not.toThrow();
+  it('prefers instructions over description when both are provided', () => {
+    const server = createMcpServer(makeRegistry(), {
+      ...baseOptions,
+      description: 'A helpful server',
+      instructions: 'Use the search tool first.',
+    });
+    expect(getInstructions(server)).toBe('Use the search tool first.');
+  });
+
+  it('falls back to description as instructions for backwards compatibility', () => {
+    const server = createMcpServer(makeRegistry(), {
+      ...baseOptions,
+      description: 'A helpful server',
+    });
+    expect(getInstructions(server)).toBe('A helpful server');
+  });
+
+  it('omits instructions when neither instructions nor description is set', () => {
+    const server = createMcpServer(makeRegistry(), baseOptions);
+    expect(getInstructions(server)).toBeUndefined();
   });
 
   it('passes taskStore and taskMessageQueue when taskManager is provided', () => {

--- a/packages/server/src/server/server.factory.ts
+++ b/packages/server/src/server/server.factory.ts
@@ -33,7 +33,11 @@ export function createMcpServer(
     },
     {
       capabilities: capabilities as ServerOptions['capabilities'],
-      ...(options.description ? { instructions: options.description } : {}),
+      // `instructions` is LLM guidance on initialize; falls back to
+      // `description` for backwards compatibility with pre-`instructions` configs.
+      ...(options.instructions || options.description
+        ? { instructions: options.instructions ?? options.description }
+        : {}),
       ...(taskManager
         ? {
             taskStore: taskManager.store,

--- a/packages/server/src/transport/sse/sse.service.spec.ts
+++ b/packages/server/src/transport/sse/sse.service.spec.ts
@@ -370,3 +370,43 @@ describe('SseService dynamic registration event handlers', () => {
     expect(mockRegisterTool).toHaveBeenCalledOnce();
   });
 });
+
+describe('resolveMessagesPath', () => {
+  const resolve = async () => (await import('./sse.service')).resolveMessagesPath;
+
+  it('returns the messages endpoint unchanged when the request has no prefix', async () => {
+    const fn = await resolve();
+    expect(fn({ originalUrl: '/sse' }, '/sse', '/messages')).toBe('/messages');
+  });
+
+  it('carries the global prefix from the request path into the messages path', async () => {
+    const fn = await resolve();
+    expect(fn({ originalUrl: '/api/sse' }, '/sse', '/messages')).toBe('/api/messages');
+  });
+
+  it('handles nested prefixes and query strings', async () => {
+    const fn = await resolve();
+    expect(fn({ originalUrl: '/api/v2/sse?foo=1' }, '/sse', '/messages')).toBe('/api/v2/messages');
+  });
+
+  it('reads the URL from fastify-style raw requests', async () => {
+    const fn = await resolve();
+    expect(fn({ raw: { url: '/api/sse' } }, '/sse', '/messages')).toBe('/api/messages');
+  });
+
+  it('normalizes endpoints without leading slashes', async () => {
+    const fn = await resolve();
+    expect(fn({ originalUrl: '/api/sse' }, 'sse', 'messages')).toBe('/api/messages');
+  });
+
+  it('falls back to the configured endpoint when the request is unreadable', async () => {
+    const fn = await resolve();
+    expect(fn(undefined, '/sse', '/messages')).toBe('/messages');
+    expect(fn({}, '/sse', 'messages')).toBe('/messages');
+  });
+
+  it('falls back when the request path does not end with the SSE endpoint', async () => {
+    const fn = await resolve();
+    expect(fn({ originalUrl: '/healthz' }, '/sse', '/messages')).toBe('/messages');
+  });
+});

--- a/packages/server/src/transport/sse/sse.service.ts
+++ b/packages/server/src/transport/sse/sse.service.ts
@@ -6,6 +6,7 @@ import { MCP_OPTIONS, McpTransportType } from '@nest-mcp/common';
 import { Inject, Injectable, Logger, type OnModuleDestroy, Optional } from '@nestjs/common';
 import {
   DEFAULT_PING_INTERVAL,
+  DEFAULT_SSE_ENDPOINT,
   DEFAULT_SSE_MESSAGES_ENDPOINT,
 } from '../../constants/module.constants';
 import type {
@@ -30,6 +31,34 @@ import {
   registerToolOnServer,
 } from '../register-handlers';
 import type { SdkHandle } from '../register-handlers';
+
+/**
+ * Derive the messages-endpoint path advertised to the client in the SSE
+ * `endpoint` event. When the app mounts controllers behind a path prefix
+ * (`app.setGlobalPrefix`, `RouterModule`), the incoming SSE request path
+ * carries that prefix — the advertised messages path must carry it too or
+ * clients POST their JSON-RPC messages to the unprefixed (404) route.
+ *
+ * Exported for tests.
+ */
+export function resolveMessagesPath(
+  req: unknown,
+  sseEndpoint: string,
+  messagesEndpoint: string,
+): string {
+  const messagesPath = messagesEndpoint.startsWith('/') ? messagesEndpoint : `/${messagesEndpoint}`;
+  const r = req as
+    | { originalUrl?: string; url?: string; raw?: { originalUrl?: string; url?: string } }
+    | undefined;
+  const rawUrl = r?.originalUrl ?? r?.raw?.originalUrl ?? r?.url ?? r?.raw?.url;
+  if (typeof rawUrl !== 'string' || rawUrl.length === 0) return messagesPath;
+
+  const path = rawUrl.split('?')[0].replace(/\/+$/, '');
+  const ssePath = sseEndpoint.startsWith('/') ? sseEndpoint : `/${sseEndpoint}`;
+  if (path === ssePath || !path.endsWith(ssePath)) return messagesPath;
+
+  return `${path.slice(0, -ssePath.length)}${messagesPath}`;
+}
 
 @Injectable()
 export class SseService implements OnModuleDestroy {
@@ -61,8 +90,10 @@ export class SseService implements OnModuleDestroy {
   async createConnection(req: unknown, res: unknown): Promise<void> {
     const messagesEndpoint =
       this.options.transportOptions?.sse?.messagesEndpoint ?? DEFAULT_SSE_MESSAGES_ENDPOINT;
+    const sseEndpoint = this.options.transportOptions?.sse?.endpoint ?? DEFAULT_SSE_ENDPOINT;
+    const advertisedPath = resolveMessagesPath(req, sseEndpoint, messagesEndpoint);
 
-    const transport = new SSEServerTransport(messagesEndpoint, res as unknown as ServerResponse);
+    const transport = new SSEServerTransport(advertisedPath, res as unknown as ServerResponse);
     const sessionId = transport.sessionId;
 
     const server = createMcpServer(this.registry, this.options, this.taskManager);

--- a/packages/server/src/transport/streamable-http/streamable.service.ts
+++ b/packages/server/src/transport/streamable-http/streamable.service.ts
@@ -220,7 +220,7 @@ export class StreamableHttpService implements OnModuleInit, OnModuleDestroy {
   private async handleStatelessPost(req: unknown, res: unknown): Promise<void> {
     const transport = new StreamableHTTPServerTransport(this.buildTransportOptions(true));
 
-    const server = this.createAndConnectServer(
+    const { server } = this.createAndConnectServer(
       transport,
       `stateless-${randomUUID().slice(0, 8)}`,
       req,
@@ -262,7 +262,7 @@ export class StreamableHttpService implements OnModuleInit, OnModuleDestroy {
       if (sid) this.cleanupSession(sid);
     };
 
-    const server = this.createAndConnectServer(transport, 'pending', req);
+    const { server, ctx } = this.createAndConnectServer(transport, 'pending', req);
 
     await transport.handleRequest(
       req as unknown as IncomingMessage,
@@ -271,8 +271,11 @@ export class StreamableHttpService implements OnModuleInit, OnModuleDestroy {
 
     const sessionId = transport.sessionId;
     if (sessionId) {
+      ctx.sessionId = sessionId;
       this.transports.set(sessionId, transport);
       this.servers.set(sessionId, server);
+      this.contexts.set(sessionId, ctx);
+      this.sdkHandles.set(sessionId, new Map());
 
       const oauth = this.oauthOptions;
       const auth = reqObj.auth;
@@ -291,7 +294,7 @@ export class StreamableHttpService implements OnModuleInit, OnModuleDestroy {
     transport: StreamableHTTPServerTransport,
     label: string,
     req?: unknown,
-  ): McpServer {
+  ): { server: McpServer; ctx: McpExecutionContext } {
     const server = createMcpServer(this.registry, this.options, this.taskManager);
     const subMgr = this.subscriptionManager;
     const ctx = this.contextFactory.createContext({
@@ -311,14 +314,12 @@ export class StreamableHttpService implements OnModuleInit, OnModuleDestroy {
       this.subscriptionManager,
     );
 
-    // Only store context/handles for stateful sessions (label !== stateless-*)
-    if (!label.startsWith('stateless-')) {
-      this.contexts.set(label, ctx);
-      this.sdkHandles.set(label, new Map());
-    }
-
     server.connect(transport);
-    return server;
+    // The caller stores ctx under the real session id once the transport
+    // assigns one — stateful session ids only exist after the initialize
+    // request is handled, so keying here (under a placeholder label) would
+    // orphan the entry and break registry-event propagation to the session.
+    return { server, ctx };
   }
 
   private subscribeToRegistryEvents(): void {

--- a/packages/server/test/e2e/async-options.e2e.spec.ts
+++ b/packages/server/test/e2e/async-options.e2e.spec.ts
@@ -1,0 +1,66 @@
+import 'reflect-metadata';
+import type { McpModuleOptions, McpOptionsFactory } from '@nest-mcp/common';
+import { McpTransportType } from '@nest-mcp/common';
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpModule, Tool } from '../../src';
+import { connectStreamable, createMcpApp } from './helpers';
+import type { E2eApp } from './helpers';
+
+@Injectable()
+class AsyncTools {
+  @Tool({ name: 'ping', description: 'Ping', parameters: z.object({}) })
+  ping() {
+    return 'pong';
+  }
+}
+
+@Injectable()
+class OptionsFromClass implements McpOptionsFactory {
+  constructor() {}
+
+  createMcpOptions(): McpModuleOptions {
+    return {
+      name: 'use-class-server',
+      version: '3.2.1',
+      instructions: 'Built by an options factory class.',
+      transport: McpTransportType.STREAMABLE_HTTP,
+    };
+  }
+}
+
+describe('forRootAsync useClass e2e', () => {
+  let server: E2eApp;
+
+  beforeAll(async () => {
+    server = await createMcpApp({
+      imports: [
+        McpModule.forRootAsync({
+          transport: McpTransportType.STREAMABLE_HTTP,
+          useClass: OptionsFromClass,
+        }),
+      ],
+      providers: [AsyncTools],
+    });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('boots controllers and serves options produced by the factory class', async () => {
+    const client = await connectStreamable(server.baseUrl);
+    try {
+      expect(client.getServerVersion()).toMatchObject({
+        name: 'use-class-server',
+        version: '3.2.1',
+      });
+      expect(client.getInstructions()).toBe('Built by an options factory class.');
+
+      const result = await client.callTool({ name: 'ping', arguments: {} });
+      expect(result.content).toEqual([{ type: 'text', text: 'pong' }]);
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/packages/server/test/e2e/dynamic.e2e.spec.ts
+++ b/packages/server/test/e2e/dynamic.e2e.spec.ts
@@ -1,0 +1,85 @@
+import 'reflect-metadata';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { McpTransportType } from '@nest-mcp/common';
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpModule, McpToolBuilder, Tool } from '../../src';
+import { connectStreamable, createMcpApp, waitFor } from './helpers';
+import type { E2eApp } from './helpers';
+
+@Injectable()
+class StaticTools {
+  @Tool({ name: 'static-tool', description: 'Always there', parameters: z.object({}) })
+  staticTool() {
+    return 'static';
+  }
+}
+
+describe('dynamic capabilities e2e', () => {
+  let server: E2eApp;
+  let client: Client;
+
+  beforeAll(async () => {
+    server = await createMcpApp({
+      imports: [
+        McpModule.forRoot({
+          name: 'dynamic-server',
+          version: '1.0.0',
+          transport: McpTransportType.STREAMABLE_HTTP,
+        }),
+      ],
+      providers: [StaticTools],
+    });
+    client = await connectStreamable(server.baseUrl);
+    // The client opens its standalone GET notification stream asynchronously
+    // after initialize; notifications sent before it connects are dropped
+    // (no event store configured). Give it a moment to attach.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it('registers a tool at runtime, notifies clients, and serves calls to it', async () => {
+    let listChanged = 0;
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+      listChanged++;
+    });
+
+    const builder = server.app.get(McpToolBuilder);
+    builder.register({
+      name: 'runtime-tool',
+      description: 'Registered after boot',
+      parameters: z.object({ value: z.string() }),
+      handler: async (args) => `runtime:${String(args.value)}`,
+    });
+
+    await waitFor(() => listChanged >= 1);
+
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toEqual(
+      expect.arrayContaining(['static-tool', 'runtime-tool']),
+    );
+
+    const result = await client.callTool({ name: 'runtime-tool', arguments: { value: 'x' } });
+    expect(result.content).toEqual([{ type: 'text', text: 'runtime:x' }]);
+  });
+
+  it('unregisters a tool at runtime and notifies clients again', async () => {
+    let listChanged = 0;
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+      listChanged++;
+    });
+
+    const builder = server.app.get(McpToolBuilder);
+    builder.unregister('runtime-tool');
+
+    await waitFor(() => listChanged >= 1);
+
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).not.toContain('runtime-tool');
+  });
+});

--- a/packages/server/test/e2e/global-prefix.e2e.spec.ts
+++ b/packages/server/test/e2e/global-prefix.e2e.spec.ts
@@ -1,0 +1,62 @@
+import 'reflect-metadata';
+import { McpTransportType } from '@nest-mcp/common';
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpModule, Tool } from '../../src';
+import { connectSse, connectStreamable, createMcpApp } from './helpers';
+import type { E2eApp } from './helpers';
+
+@Injectable()
+class PrefixedTools {
+  @Tool({ name: 'echo', description: 'Echo input', parameters: z.object({ text: z.string() }) })
+  echo({ text }: { text: string }) {
+    return text;
+  }
+}
+
+/** Both HTTP transports must work behind `app.setGlobalPrefix()`. */
+describe('global prefix e2e', () => {
+  let server: E2eApp;
+
+  beforeAll(async () => {
+    server = await createMcpApp(
+      {
+        imports: [
+          McpModule.forRoot({
+            name: 'prefixed-server',
+            version: '1.0.0',
+            transport: [McpTransportType.STREAMABLE_HTTP, McpTransportType.SSE],
+          }),
+        ],
+        providers: [PrefixedTools],
+      },
+      (app) => app.setGlobalPrefix('api'),
+    );
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('serves streamable HTTP under the prefix', async () => {
+    const client = await connectStreamable(server.baseUrl, { endpoint: '/api/mcp' });
+    try {
+      const result = await client.callTool({ name: 'echo', arguments: { text: 'prefixed' } });
+      expect(result.content).toEqual([{ type: 'text', text: 'prefixed' }]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('serves SSE under the prefix and advertises a prefixed messages endpoint', async () => {
+    // callTool only works if the SSE `endpoint` event pointed the client at
+    // /api/messages (a bare /messages would 404).
+    const client = await connectSse(server.baseUrl, '/api/sse');
+    try {
+      const result = await client.callTool({ name: 'echo', arguments: { text: 'sse-prefixed' } });
+      expect(result.content).toEqual([{ type: 'text', text: 'sse-prefixed' }]);
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/packages/server/test/e2e/helpers.ts
+++ b/packages/server/test/e2e/helpers.ts
@@ -1,0 +1,82 @@
+import 'reflect-metadata';
+import type { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Module } from '@nestjs/common';
+import type { INestApplication, ModuleMetadata } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+export interface E2eApp {
+  app: INestApplication;
+  baseUrl: string;
+  close(): Promise<void>;
+}
+
+/** Boot a real Nest app (Express) from module metadata on an ephemeral port. */
+export async function createMcpApp(
+  metadata: ModuleMetadata,
+  configure?: (app: INestApplication) => void,
+): Promise<E2eApp> {
+  @Module(metadata)
+  class E2eRootModule {}
+
+  // bodyParser must stay off: the SDK transports read the raw request stream
+  // themselves (same setup as every app under apps/).
+  const app = await NestFactory.create(E2eRootModule, {
+    logger: false,
+    abortOnError: false,
+    bodyParser: false,
+  });
+  configure?.(app);
+  await app.listen(0, '127.0.0.1');
+  const { port } = app.getHttpServer().address() as AddressInfo;
+  return {
+    app,
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => app.close(),
+  };
+}
+
+export interface ConnectOptions {
+  endpoint?: string;
+  headers?: Record<string, string>;
+}
+
+/** Connect a real SDK client over streamable HTTP. */
+export async function connectStreamable(
+  baseUrl: string,
+  options: ConnectOptions = {},
+): Promise<Client> {
+  const client = new Client({ name: 'e2e-client', version: '1.0.0' });
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${baseUrl}${options.endpoint ?? '/mcp'}`),
+    options.headers ? { requestInit: { headers: options.headers } } : undefined,
+  );
+  await client.connect(transport);
+  return client;
+}
+
+/** Connect a real SDK client over the legacy HTTP+SSE transport. */
+export async function connectSse(baseUrl: string, endpoint = '/sse'): Promise<Client> {
+  const client = new Client({ name: 'e2e-client', version: '1.0.0' });
+  await client.connect(new SSEClientTransport(new URL(`${baseUrl}${endpoint}`)));
+  return client;
+}
+
+/** Poll until `predicate` returns a truthy value or `timeoutMs` elapses. */
+export async function waitFor<T>(
+  predicate: () => T | undefined | false,
+  timeoutMs = 5000,
+  intervalMs = 25,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = predicate();
+    if (value) return value;
+    if (Date.now() > deadline) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}

--- a/packages/server/test/e2e/multi-server.e2e.spec.ts
+++ b/packages/server/test/e2e/multi-server.e2e.spec.ts
@@ -1,0 +1,95 @@
+import 'reflect-metadata';
+import { McpTransportType } from '@nest-mcp/common';
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpModule, Tool } from '../../src';
+import { connectStreamable, createMcpApp } from './helpers';
+import type { E2eApp } from './helpers';
+
+@Injectable()
+class WeatherTools {
+  @Tool({ name: 'get-weather', description: 'Weather', parameters: z.object({}) })
+  getWeather() {
+    return 'sunny';
+  }
+}
+
+@Injectable()
+class AdminTools {
+  @Tool({ name: 'admin-action', description: 'Admin', parameters: z.object({}) })
+  adminAction() {
+    return 'done';
+  }
+}
+
+/**
+ * Two McpModule.forRoot() instances in one app, each with its own endpoint
+ * and forFeature(serverName)-scoped tools, must stay fully isolated.
+ */
+describe('multi-server e2e', () => {
+  let server: E2eApp;
+
+  beforeAll(async () => {
+    server = await createMcpApp({
+      imports: [
+        McpModule.forRoot({
+          name: 'weather-server',
+          version: '1.0.0',
+          transport: McpTransportType.STREAMABLE_HTTP,
+          transportOptions: { streamableHttp: { endpoint: '/weather-mcp' } },
+        }),
+        McpModule.forRoot({
+          name: 'admin-server',
+          version: '2.0.0',
+          transport: McpTransportType.STREAMABLE_HTTP,
+          transportOptions: { streamableHttp: { endpoint: '/admin-mcp' } },
+        }),
+        McpModule.forFeature([WeatherTools], 'weather-server'),
+        McpModule.forFeature([AdminTools], 'admin-server'),
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('serves each endpoint with its own server identity', async () => {
+    const weather = await connectStreamable(server.baseUrl, { endpoint: '/weather-mcp' });
+    const admin = await connectStreamable(server.baseUrl, { endpoint: '/admin-mcp' });
+    try {
+      expect(weather.getServerVersion()).toMatchObject({ name: 'weather-server' });
+      expect(admin.getServerVersion()).toMatchObject({ name: 'admin-server' });
+    } finally {
+      await weather.close();
+      await admin.close();
+    }
+  });
+
+  it('scopes forFeature tools to their target server', async () => {
+    const weather = await connectStreamable(server.baseUrl, { endpoint: '/weather-mcp' });
+    const admin = await connectStreamable(server.baseUrl, { endpoint: '/admin-mcp' });
+    try {
+      const weatherTools = (await weather.listTools()).tools.map((t) => t.name);
+      const adminTools = (await admin.listTools()).tools.map((t) => t.name);
+
+      expect(weatherTools).toContain('get-weather');
+      expect(weatherTools).not.toContain('admin-action');
+      expect(adminTools).toContain('admin-action');
+      expect(adminTools).not.toContain('get-weather');
+    } finally {
+      await weather.close();
+      await admin.close();
+    }
+  });
+
+  it('routes tool calls to the right server', async () => {
+    const weather = await connectStreamable(server.baseUrl, { endpoint: '/weather-mcp' });
+    try {
+      const result = await weather.callTool({ name: 'get-weather', arguments: {} });
+      expect(result.content).toEqual([{ type: 'text', text: 'sunny' }]);
+    } finally {
+      await weather.close();
+    }
+  });
+});

--- a/packages/server/test/e2e/protocol-version.e2e.spec.ts
+++ b/packages/server/test/e2e/protocol-version.e2e.spec.ts
@@ -1,0 +1,94 @@
+import 'reflect-metadata';
+import { McpTransportType } from '@nest-mcp/common';
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpModule, Tool } from '../../src';
+import { createMcpApp } from './helpers';
+import type { E2eApp } from './helpers';
+
+@Injectable()
+class VersionedTools {
+  @Tool({ name: 'noop', description: 'No-op', parameters: z.object({}) })
+  noop() {
+    return 'ok';
+  }
+}
+
+/**
+ * Pins the SDK transport's MCP-Protocol-Version header enforcement
+ * (spec 2025-06-18) as it behaves through our stack: requests after
+ * initialize carrying an unsupported version header must be rejected.
+ */
+describe('MCP-Protocol-Version header e2e', () => {
+  let server: E2eApp;
+
+  beforeAll(async () => {
+    server = await createMcpApp({
+      imports: [
+        McpModule.forRoot({
+          name: 'version-server',
+          version: '1.0.0',
+          transport: McpTransportType.STREAMABLE_HTTP,
+        }),
+      ],
+      providers: [VersionedTools],
+    });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  async function initializeSession(): Promise<string> {
+    const res = await fetch(`${server.baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'raw-e2e', version: '1.0.0' },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const sessionId = res.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+    await res.body?.cancel();
+    return sessionId as string;
+  }
+
+  function postToolsList(sessionId: string, protocolVersion?: string): Promise<Response> {
+    return fetch(`${server.baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        'mcp-session-id': sessionId,
+        ...(protocolVersion ? { 'mcp-protocol-version': protocolVersion } : {}),
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+    });
+  }
+
+  it('accepts requests carrying a supported protocol version header', async () => {
+    const sessionId = await initializeSession();
+    const res = await postToolsList(sessionId, '2025-06-18');
+    expect(res.status).toBe(200);
+    await res.body?.cancel();
+  });
+
+  it('rejects requests carrying an unsupported protocol version header with 400', async () => {
+    const sessionId = await initializeSession();
+    const res = await postToolsList(sessionId, '1999-01-01');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(JSON.stringify(body)).toContain('protocol version');
+  });
+});

--- a/packages/server/test/e2e/request-scoped.e2e.spec.ts
+++ b/packages/server/test/e2e/request-scoped.e2e.spec.ts
@@ -1,0 +1,73 @@
+import 'reflect-metadata';
+import { McpTransportType } from '@nest-mcp/common';
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { z } from 'zod';
+import { McpModule, Tool } from '../../src';
+import { connectStreamable, createMcpApp } from './helpers';
+import type { E2eApp } from './helpers';
+
+/**
+ * The MCP request context registered for scoped providers is the transport's
+ * request info (`{ headers }`), not a full Express request.
+ */
+interface McpRequestInfo {
+  headers?: Record<string, string | string[] | undefined>;
+}
+
+@Injectable({ scope: Scope.REQUEST })
+class TenantTools {
+  constructor(@Inject(REQUEST) private readonly request: McpRequestInfo) {}
+
+  @Tool({ name: 'whoami', description: 'Echo the calling tenant', parameters: z.object({}) })
+  whoami() {
+    const tenant = this.request?.headers?.['x-tenant'] ?? 'anonymous';
+    return `tenant:${String(tenant)}`;
+  }
+}
+
+describe('request-scoped provider e2e', () => {
+  let server: E2eApp;
+
+  beforeAll(async () => {
+    server = await createMcpApp({
+      imports: [
+        McpModule.forRoot({
+          name: 'scoped-server',
+          version: '1.0.0',
+          transport: McpTransportType.STREAMABLE_HTTP,
+        }),
+      ],
+      providers: [TenantTools],
+    });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('discovers tools on request-scoped providers', async () => {
+    const client = await connectStreamable(server.baseUrl);
+    try {
+      const { tools } = await client.listTools();
+      expect(tools.map((t) => t.name)).toContain('whoami');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('resolves a fresh provider per call with the caller request injected', async () => {
+    const acme = await connectStreamable(server.baseUrl, { headers: { 'x-tenant': 'acme' } });
+    const globex = await connectStreamable(server.baseUrl, { headers: { 'x-tenant': 'globex' } });
+    try {
+      const acmeResult = await acme.callTool({ name: 'whoami', arguments: {} });
+      const globexResult = await globex.callTool({ name: 'whoami', arguments: {} });
+
+      expect(acmeResult.content).toEqual([{ type: 'text', text: 'tenant:acme' }]);
+      expect(globexResult.content).toEqual([{ type: 'text', text: 'tenant:globex' }]);
+    } finally {
+      await acme.close();
+      await globex.close();
+    }
+  });
+});

--- a/packages/server/test/e2e/sse.e2e.spec.ts
+++ b/packages/server/test/e2e/sse.e2e.spec.ts
@@ -1,0 +1,50 @@
+import 'reflect-metadata';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { McpTransportType } from '@nest-mcp/common';
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpModule, Tool } from '../../src';
+import { connectSse, createMcpApp } from './helpers';
+import type { E2eApp } from './helpers';
+
+@Injectable()
+class SseTools {
+  @Tool({ name: 'echo', description: 'Echo input', parameters: z.object({ text: z.string() }) })
+  echo({ text }: { text: string }) {
+    return text;
+  }
+}
+
+describe('legacy HTTP+SSE e2e', () => {
+  let server: E2eApp;
+  let client: Client;
+
+  beforeAll(async () => {
+    server = await createMcpApp({
+      imports: [
+        McpModule.forRoot({
+          name: 'sse-server',
+          version: '1.0.0',
+          transport: McpTransportType.SSE,
+        }),
+      ],
+      providers: [SseTools],
+    });
+    client = await connectSse(server.baseUrl);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it('lists tools over SSE', async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain('echo');
+  });
+
+  it('calls tools over SSE', async () => {
+    const result = await client.callTool({ name: 'echo', arguments: { text: 'ping' } });
+    expect(result.content).toEqual([{ type: 'text', text: 'ping' }]);
+  });
+});

--- a/packages/server/test/e2e/streamable.e2e.spec.ts
+++ b/packages/server/test/e2e/streamable.e2e.spec.ts
@@ -1,0 +1,228 @@
+import 'reflect-metadata';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { McpExecutionContext } from '@nest-mcp/common';
+import { McpTransportType } from '@nest-mcp/common';
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import { McpModule, Prompt, Public, Resource, Scopes, Tool } from '../../src';
+import { connectStreamable, createMcpApp, waitFor } from './helpers';
+import type { E2eApp } from './helpers';
+
+@Injectable()
+class KitchenSink {
+  @Tool({ name: 'greet', description: 'Greet someone', parameters: z.object({ name: z.string() }) })
+  greet({ name }: { name: string }) {
+    return `hello ${name}`;
+  }
+
+  @Tool({
+    name: 'add',
+    description: 'Add two numbers',
+    parameters: z.object({ a: z.number(), b: z.number() }),
+    outputSchema: z.object({ sum: z.number() }),
+  })
+  add({ a, b }: { a: number; b: number }) {
+    return { sum: a + b };
+  }
+
+  @Tool({ name: 'long-task', description: 'Reports progress', parameters: z.object({}) })
+  async longTask(_args: Record<string, never>, ctx: McpExecutionContext) {
+    await ctx.reportProgress({ progress: 50, total: 100 });
+    await ctx.reportProgress({ progress: 100, total: 100 });
+    return 'done';
+  }
+
+  @Tool({ name: 'chatty', description: 'Emits an info log', parameters: z.object({}) })
+  chatty(_args: Record<string, never>, ctx: McpExecutionContext) {
+    ctx.log.info('hello from chatty');
+    return 'ok';
+  }
+
+  @Tool({ name: 'grumpy', description: 'Emits an error log', parameters: z.object({}) })
+  grumpy(_args: Record<string, never>, ctx: McpExecutionContext) {
+    ctx.log.error('boom from grumpy');
+    return 'ok';
+  }
+
+  @Prompt({
+    name: 'greeting',
+    description: 'Greeting prompt',
+    parameters: z.object({ tone: z.enum(['formal', 'casual']) }),
+  })
+  greeting({ tone }: { tone: string }) {
+    return { messages: [{ role: 'user', content: { type: 'text', text: `be ${tone}` } }] };
+  }
+
+  @Resource({
+    uri: 'app://config',
+    name: 'config',
+    description: 'App config',
+    mimeType: 'application/json',
+  })
+  config() {
+    return JSON.stringify({ ok: true });
+  }
+}
+
+describe('streamable HTTP e2e', () => {
+  let server: E2eApp;
+  let client: Client;
+
+  beforeAll(async () => {
+    server = await createMcpApp({
+      imports: [
+        McpModule.forRoot({
+          name: 'e2e-server',
+          version: '1.0.0',
+          description: 'Server used by the e2e suite',
+          instructions: 'Always greet before adding numbers.',
+          transport: McpTransportType.STREAMABLE_HTTP,
+        }),
+      ],
+      providers: [KitchenSink],
+    });
+    client = await connectStreamable(server.baseUrl);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it('returns the dedicated instructions on initialize', () => {
+    expect(client.getInstructions()).toBe('Always greet before adding numbers.');
+  });
+
+  it('reports server info from module options', () => {
+    expect(client.getServerVersion()).toMatchObject({ name: 'e2e-server', version: '1.0.0' });
+  });
+
+  it('lists decorated tools', async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining(['greet', 'add', 'long-task', 'chatty', 'grumpy']),
+    );
+  });
+
+  it('calls a tool and returns text content', async () => {
+    const result = await client.callTool({ name: 'greet', arguments: { name: 'ada' } });
+    expect(result.content).toEqual([{ type: 'text', text: 'hello ada' }]);
+  });
+
+  it('validates output schema and returns structuredContent', async () => {
+    const result = await client.callTool({ name: 'add', arguments: { a: 1, b: 2 } });
+    expect(result.structuredContent).toEqual({ sum: 3 });
+  });
+
+  it('surfaces invalid params as an isError tool result, not a protocol error', async () => {
+    const result = await client.callTool({ name: 'greet', arguments: { name: 42 } });
+    expect(result.isError).toBe(true);
+  });
+
+  it('streams progress notifications for the calling request', async () => {
+    const progress: Array<{ progress: number }> = [];
+    await client.callTool({ name: 'long-task', arguments: {} }, undefined, {
+      onprogress: (p) => progress.push(p),
+    });
+    await waitFor(() => progress.length >= 2);
+    expect(progress[0]).toMatchObject({ progress: 50, total: 100 });
+    expect(progress[1]).toMatchObject({ progress: 100, total: 100 });
+  });
+
+  it('delivers ctx.log output as notifications/message', async () => {
+    const messages: Array<{ level: string }> = [];
+    client.setNotificationHandler(LoggingMessageNotificationSchema, (n) => {
+      messages.push(n.params as { level: string });
+    });
+
+    await client.callTool({ name: 'chatty', arguments: {} });
+    await waitFor(() => messages.some((m) => m.level === 'info'));
+  });
+
+  it('honors logging/setLevel: messages below the level are suppressed', async () => {
+    const messages: Array<{ level: string }> = [];
+    client.setNotificationHandler(LoggingMessageNotificationSchema, (n) => {
+      messages.push(n.params as { level: string });
+    });
+
+    await client.setLoggingLevel('error');
+    await client.callTool({ name: 'chatty', arguments: {} });
+    await client.callTool({ name: 'grumpy', arguments: {} });
+    await waitFor(() => messages.some((m) => m.level === 'error'));
+
+    expect(messages.some((m) => m.level === 'info')).toBe(false);
+  });
+
+  it('serves prompts with validated arguments', async () => {
+    const result = await client.getPrompt({ name: 'greeting', arguments: { tone: 'formal' } });
+    expect(result.messages).toEqual([
+      { role: 'user', content: { type: 'text', text: 'be formal' } },
+    ]);
+  });
+
+  it('completes enum prompt arguments by prefix (default completion)', async () => {
+    const result = await client.complete({
+      ref: { type: 'ref/prompt', name: 'greeting' },
+      argument: { name: 'tone', value: 'f' },
+    });
+    expect(result.completion.values).toEqual(['formal']);
+  });
+
+  it('reads resources', async () => {
+    const result = await client.readResource({ uri: 'app://config' });
+    expect(result.contents[0]).toMatchObject({ uri: 'app://config' });
+    expect(JSON.parse((result.contents[0] as { text: string }).text)).toEqual({ ok: true });
+  });
+});
+
+describe('streamable HTTP e2e — securitySchemes advertisement', () => {
+  @Injectable()
+  class GatedTools {
+    @Tool({ name: 'open-tool', description: 'Public tool', parameters: z.object({}) })
+    @Public()
+    openTool() {
+      return 'open';
+    }
+
+    @Tool({ name: 'scoped-tool', description: 'Needs scopes', parameters: z.object({}) })
+    @Scopes(['read:data'])
+    scopedTool() {
+      return 'scoped';
+    }
+  }
+
+  let server: E2eApp;
+  let client: Client;
+
+  beforeAll(async () => {
+    server = await createMcpApp({
+      imports: [
+        McpModule.forRoot({
+          name: 'gated-server',
+          version: '1.0.0',
+          transport: McpTransportType.STREAMABLE_HTTP,
+          advertiseSecuritySchemes: true,
+        }),
+      ],
+      providers: [GatedTools],
+    });
+    client = await connectStreamable(server.baseUrl);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it('advertises noauth for @Public tools and oauth2+scopes for @Scopes tools', async () => {
+    const { tools } = await client.listTools();
+    const byName = new Map(tools.map((t) => [t.name, t]));
+
+    expect(byName.get('open-tool')?._meta?.securitySchemes).toEqual([{ type: 'noauth' }]);
+    expect(byName.get('scoped-tool')?._meta?.securitySchemes).toEqual([
+      { type: 'oauth2', scopes: ['read:data'] },
+    ]);
+  });
+});

--- a/packages/server/vitest.e2e.config.ts
+++ b/packages/server/vitest.e2e.config.ts
@@ -1,0 +1,25 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  // esbuild (vitest's default transform) does not emit `design:paramtypes`,
+  // which real NestJS DI needs. The e2e suite boots real Nest apps, so
+  // transform with SWC and decorator metadata enabled instead.
+  plugins: [
+    swc.vite({
+      module: { type: 'es6' },
+      jsc: {
+        parser: { syntax: 'typescript', decorators: true },
+        transform: { legacyDecorator: true, decoratorMetadata: true },
+        target: 'es2022',
+      },
+    }),
+  ],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/e2e/**/*.e2e.spec.ts'],
+    testTimeout: 15000,
+    hookTimeout: 15000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(@swc/core@1.15.41)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -417,6 +417,9 @@ importers:
       '@nestjs/testing':
         specifier: ^11.0.0
         version: 11.1.14(@nestjs/common@11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/platform-express@11.1.14)
+      '@swc/core':
+        specifier: ^1.15.41
+        version: 1.15.41
       express:
         specifier: ^4.21.0
         version: 4.22.1
@@ -432,6 +435,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      unplugin-swc:
+        specifier: ^1.5.9
+        version: 1.5.9(@swc/core@1.15.41)(rollup@4.59.0)
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.11)(jsdom@24.1.3)
@@ -899,6 +905,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1008,6 +1017,15 @@ packages:
     resolution: {integrity: sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==}
     engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
     hasBin: true
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -1133,6 +1151,93 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@swc/core-darwin-arm64@1.15.41':
+    resolution: {integrity: sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.41':
+    resolution: {integrity: sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    resolution: {integrity: sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    resolution: {integrity: sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    resolution: {integrity: sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    resolution: {integrity: sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    resolution: {integrity: sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    resolution: {integrity: sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    resolution: {integrity: sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    resolution: {integrity: sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    resolution: {integrity: sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    resolution: {integrity: sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.41':
+    resolution: {integrity: sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
@@ -1486,6 +1591,9 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2471,6 +2579,15 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin-swc@1.5.9:
+    resolution: {integrity: sha512-RKwK3yf0M+MN17xZfF14bdKqfx0zMXYdtOdxLiE6jHAoidupKq3jGdJYANyIM1X/VmABhh1WpdO+/f4+Ol89+g==}
+    peerDependencies:
+      '@swc/core': ^1.2.108
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
@@ -2553,6 +2670,9 @@ packages:
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -2987,6 +3107,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -3110,6 +3235,14 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  '@rollup/pluginutils@5.4.0(rollup@4.59.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.59.0
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -3184,6 +3317,66 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@swc/core-darwin-arm64@1.15.41':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core@1.15.41':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.41
+      '@swc/core-darwin-x64': 1.15.41
+      '@swc/core-linux-arm-gnueabihf': 1.15.41
+      '@swc/core-linux-arm64-gnu': 1.15.41
+      '@swc/core-linux-arm64-musl': 1.15.41
+      '@swc/core-linux-ppc64-gnu': 1.15.41
+      '@swc/core-linux-s390x-gnu': 1.15.41
+      '@swc/core-linux-x64-gnu': 1.15.41
+      '@swc/core-linux-x64-musl': 1.15.41
+      '@swc/core-win32-arm64-msvc': 1.15.41
+      '@swc/core-win32-ia32-msvc': 1.15.41
+      '@swc/core-win32-x64-msvc': 1.15.41
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.26':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -3563,6 +3756,8 @@ snapshots:
   escape-html@1.0.3: {}
 
   esprima@4.0.1: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -4497,7 +4692,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(@swc/core@1.15.41)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -4517,6 +4712,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
+      '@swc/core': 1.15.41
       postcss: 8.5.6
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4595,6 +4791,22 @@ snapshots:
   universalify@0.2.0: {}
 
   unpipe@1.0.0: {}
+
+  unplugin-swc@1.5.9(@swc/core@1.15.41)(rollup@4.59.0):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.59.0)
+      '@swc/core': 1.15.41
+      load-tsconfig: 0.2.5
+      unplugin: 2.3.11
+    transitivePeerDependencies:
+      - rollup
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.3
+      webpack-virtual-modules: 0.6.2
 
   url-parse@1.5.10:
     dependencies:
@@ -4675,6 +4887,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   webidl-conversions@7.0.0: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-encoding@3.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

Server hardening pass: fixes two session-level bugs, adds five features, and introduces a transport-level e2e suite that drives real Nest apps with real `@modelcontextprotocol/sdk` clients.

## Bug fixes

- **`logging/setLevel` was silently ignored**: the SDK keys client-set levels by transport session id, but `context.factory` sent log messages without one, so per-session filtering never applied. Now pinned by e2e.
- **Streamable session state keyed under `'pending'`**: stateful sessions stored their execution context under a placeholder label while servers used the real session id — dynamic tool registration never propagated `listChanged` to live sessions, and each new session leaked the previous `'pending'` entry.

## Features

- **Request-scoped DI for feature providers**: scoped providers were previously registered as never-constructed shell instances (all deps `undefined`). The scanner now detects them via `isDependencyTreeStatic()` and the executor resolves a fresh instance per call with `@Inject(REQUEST)` support.
- **`instructions` module option** — distinct from `description` (kept as fallback).
- **`advertiseSecuritySchemes`** (opt-in) — `tools/list` entries carry `_meta.securitySchemes` derived from `@Public`/`@Scopes`.
- **`forRootAsync` `useClass` / `useExisting` / `extraProviders`** via `McpOptionsFactory`.
- **SSE behind path prefixes**: the SSE `endpoint` event now derives the messages URL from the incoming request path, so `app.setGlobalPrefix()` works.

## Tests

- New transport-level e2e suite (`pnpm test:e2e` in `packages/server`): 27 tests / 8 files — streamable (incl. setLevel filtering, progress, structured output), SSE, request-scoped DI, multi-server isolation, dynamic `listChanged`, global prefix, MCP-Protocol-Version 400 enforcement, async `useClass`.
- Unit suite grew 1,017 → 1,047; all packages green (1,742 unit + 27 e2e).
- New dev deps (server only): `unplugin-swc` + `@swc/core` — esbuild doesn't emit `design:paramtypes`, which real Nest DI needs.

## Docs

New `dependency-injection.md`, `elicitation.md`, `exposure.md`; `module.md` gains the new options, async variants, and a Logging section; quick starts now show the required `bodyParser: false`; repo-root `context7.json`.

## Verification

- `pnpm test` in all four packages (1,742 tests)
- `pnpm test:e2e` in packages/server (27 tests)
- `pnpm typecheck` + `pnpm build` clean