### PR TITLE
feat(client): runtime connection registry on McpClientsService

### DIFF
--- a/.changeset/client-runtime-registry.md
+++ b/.changeset/client-runtime-registry.md
@@ -1,0 +1,14 @@
+---
+"@nest-mcp/client": minor
+---
+
+Add runtime connection registry to `McpClientsService`: `addConnection(connection)`,
+`getOrCreate(connection)`, `removeConnection(name)`, and `has(name)`. This lets apps register and
+tear down MCP client connections at runtime — for multi-tenant gateways where upstreams are
+discovered after module init — instead of fixing all connections at `forRoot`/`forRootAsync` time.
+
+`addConnection`/`getOrCreate` are idempotent (a connected client with the same name is reused, a
+stale one is replaced, and concurrent first-connects dedupe to a single client); a client whose
+`connect()` rejects is not registered. Runtime clients join the same collection as the static ones,
+so they are returned by `getClient`/`getClients` and disconnected on application shutdown. Purely
+additive — existing `getClient`/`getClients` behavior is unchanged.

--- a/docs/client/injection.md
+++ b/docs/client/injection.md
@@ -63,11 +63,62 @@ export class DynamicService {
 |--------|---------|-------------|
 | `getClient(name)` | `McpClient` | Returns the client with the given name. Throws if not found. |
 | `getClients()` | `McpClient[]` | Returns all registered clients. |
+| `has(name)` | `boolean` | Whether a client is registered under `name` (any connection state). |
+| `addConnection(connection)` | `Promise<McpClient>` | Create + connect a client at runtime and register it. Idempotent. |
+| `getOrCreate(connection)` | `Promise<McpClient>` | Alias for `addConnection`. |
+| `removeConnection(name)` | `Promise<void>` | Disconnect + unregister a client (idempotent). |
 
 `McpClientsService` is useful when:
 - You need to iterate over all clients
 - The connection name is determined at runtime
 - You are using `forRootAsync` without `connectionNames`
+
+### Runtime connections
+
+When upstreams are not known at module init — for example a multi-tenant gateway where users
+register their own MCP servers — start with an empty static set and add connections on demand:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { McpClientModule } from '@nest-mcp/client';
+
+@Module({
+  imports: [McpClientModule.forRoot({ connections: [] })],
+})
+export class AppModule {}
+```
+
+```typescript
+@Injectable()
+export class TenantTools {
+  constructor(private readonly clients: McpClientsService) {}
+
+  async callTool(server: { id: string; url: string; token?: string }, name: string, args: unknown) {
+    // Key by a unique, stable id — runtime connection names must be unique.
+    const client = await this.clients.getOrCreate({
+      transport: 'streamable-http',
+      name: server.id,
+      url: server.url,
+      auth: server.token ? { type: 'bearer', token: server.token } : undefined,
+    });
+    return client.callTool({ name, arguments: args });
+  }
+
+  release(serverId: string) {
+    return this.clients.removeConnection(serverId);
+  }
+}
+```
+
+Notes:
+- `addConnection`/`getOrCreate` are **idempotent**: a connected client with the same name is
+  returned as-is, a disconnected one is replaced, and concurrent first-connects for the same name
+  dedupe to a single client.
+- A client whose `connect()` rejects is **not** registered; the error propagates so callers can
+  surface it.
+- Runtime clients live in the same collection as the static ones, so they are returned by
+  `getClient`/`getClients` and disconnected on application shutdown.
+- Use **unique** connection names (e.g. a server id) — lookups and removal are by name.
 
 ## getMcpClientToken
 

--- a/packages/client/src/mcp-clients.service.runtime.spec.ts
+++ b/packages/client/src/mcp-clients.service.runtime.spec.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Controllable connect behavior so we can exercise success, slow-concurrent, and failure paths.
+const hooks = vi.hoisted(() => ({
+  connect: () => Promise.resolve() as Promise<void>,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: vi.fn(() => hooks.connect()),
+    close: vi.fn().mockResolvedValue(undefined),
+    callTool: vi.fn(),
+  })),
+}));
+
+vi.mock('./transport/client-transport.factory', () => ({
+  createClientTransport: vi.fn().mockReturnValue({
+    onclose: null,
+    onerror: null,
+    close: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+import type { McpClientStreamableHttpConnection } from './interfaces/client-options.interface';
+import { McpClientsService } from './mcp-clients.service';
+
+function conn(name: string): McpClientStreamableHttpConnection {
+  return { name, transport: 'streamable-http', url: `https://example.test/${name}/mcp` };
+}
+
+describe('McpClientsService — runtime registry', () => {
+  beforeEach(() => {
+    hooks.connect = () => Promise.resolve();
+  });
+
+  describe('addConnection', () => {
+    it('creates, connects, and registers a new client', async () => {
+      const service = new McpClientsService([]);
+
+      const client = await service.addConnection(conn('alpha'));
+
+      expect(client.name).toBe('alpha');
+      expect(client.isConnected()).toBe(true);
+      expect(service.has('alpha')).toBe(true);
+      expect(service.getClient('alpha')).toBe(client);
+      expect(service.getClients()).toHaveLength(1);
+    });
+
+    it('is idempotent — returns the same connected instance without creating a second', async () => {
+      const service = new McpClientsService([]);
+
+      const first = await service.addConnection(conn('alpha'));
+      const second = await service.addConnection(conn('alpha'));
+
+      expect(second).toBe(first);
+      expect(service.getClients()).toHaveLength(1);
+    });
+
+    it('dedupes concurrent first-connects for the same name to a single client', async () => {
+      const service = new McpClientsService([]);
+      let release!: () => void;
+      hooks.connect = () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        });
+
+      const p1 = service.addConnection(conn('alpha'));
+      const p2 = service.addConnection(conn('alpha'));
+      release();
+      const [c1, c2] = await Promise.all([p1, p2]);
+
+      expect(c1).toBe(c2);
+      expect(service.getClients()).toHaveLength(1);
+    });
+
+    it('replaces a stale (disconnected) client with a fresh connection', async () => {
+      const service = new McpClientsService([]);
+
+      const stale = await service.addConnection(conn('alpha'));
+      await stale.disconnect();
+      expect(stale.isConnected()).toBe(false);
+
+      const fresh = await service.addConnection(conn('alpha'));
+
+      expect(fresh).not.toBe(stale);
+      expect(fresh.isConnected()).toBe(true);
+      expect(service.getClients()).toHaveLength(1);
+    });
+
+    it('does NOT register a client whose connect rejects, and propagates the error', async () => {
+      const service = new McpClientsService([]);
+      hooks.connect = () => Promise.reject(new Error('upstream down'));
+
+      await expect(service.addConnection(conn('alpha'))).rejects.toThrow('upstream down');
+      expect(service.has('alpha')).toBe(false);
+      expect(service.getClients()).toHaveLength(0);
+    });
+  });
+
+  describe('getOrCreate', () => {
+    it('is an alias for addConnection', async () => {
+      const service = new McpClientsService([]);
+
+      const a = await service.getOrCreate(conn('alpha'));
+      const b = await service.getOrCreate(conn('alpha'));
+
+      expect(b).toBe(a);
+      expect(service.getClients()).toHaveLength(1);
+    });
+  });
+
+  describe('removeConnection', () => {
+    it('disconnects and unregisters the client', async () => {
+      const service = new McpClientsService([]);
+      const client = await service.addConnection(conn('alpha'));
+
+      await service.removeConnection('alpha');
+
+      expect(client.isConnected()).toBe(false);
+      expect(service.has('alpha')).toBe(false);
+      expect(service.getClients()).toHaveLength(0);
+    });
+
+    it('is a no-op for an unknown name', async () => {
+      const service = new McpClientsService([]);
+      await expect(service.removeConnection('ghost')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('collection identity', () => {
+    it('mutates the registered array in place so getClients() references stay valid', async () => {
+      const service = new McpClientsService([]);
+      const ref = service.getClients();
+
+      await service.addConnection(conn('alpha'));
+      await service.removeConnection('alpha');
+
+      expect(service.getClients()).toBe(ref);
+    });
+  });
+});

--- a/packages/client/src/mcp-clients.service.ts
+++ b/packages/client/src/mcp-clients.service.ts
@@ -1,8 +1,14 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import type { McpClientConnection } from './interfaces/client-options.interface';
 import { McpClient } from './mcp-client.service';
 
 @Injectable()
 export class McpClientsService {
+  private readonly logger = new Logger('McpClientsService');
+  // In-flight connects keyed by connection name, so concurrent addConnection/getOrCreate calls
+  // for the same name share a single connect instead of racing to create duplicate clients.
+  private readonly pending = new Map<string, Promise<McpClient>>();
+
   constructor(@Inject('MCP_CLIENT_CONNECTIONS') private readonly clients: McpClient[]) {}
 
   getClient(name: string): McpClient {
@@ -15,5 +21,72 @@ export class McpClientsService {
 
   getClients(): McpClient[] {
     return this.clients;
+  }
+
+  /** Whether a client is currently registered under `name` (regardless of connection state). */
+  has(name: string): boolean {
+    return this.clients.some((c) => c.name === name);
+  }
+
+  /**
+   * Idempotently ensure a connected client for `connection.name`, creating and connecting one if
+   * absent. This is the runtime counterpart to the static `connections` passed to
+   * `McpClientModule.forRoot` — use it when upstreams are discovered at runtime (e.g. per-tenant
+   * MCP servers registered by users).
+   *
+   * - If a client with that name exists and is connected, it is returned unchanged.
+   * - If a client with that name exists but is disconnected, it is dropped and replaced with a
+   *   fresh connection.
+   * - Concurrent calls for the same name share a single connect.
+   *
+   * The new client is registered in the same collection as the static ones, so it is returned by
+   * `getClient`/`getClients` and torn down on application shutdown. A client that fails to connect
+   * is NOT registered (the rejection propagates).
+   *
+   * @throws the underlying connect error if the upstream cannot be reached.
+   */
+  async addConnection(connection: McpClientConnection): Promise<McpClient> {
+    const existing = this.clients.find((c) => c.name === connection.name);
+    if (existing?.isConnected()) return existing;
+
+    const inFlight = this.pending.get(connection.name);
+    if (inFlight) return inFlight;
+
+    const promise = (async () => {
+      // Replace a stale (disconnected) client with the same name before reconnecting fresh.
+      if (existing) await this.removeConnection(connection.name);
+      const client = new McpClient(connection.name, connection);
+      await client.connect();
+      this.clients.push(client);
+      this.logger.log(`Registered runtime MCP client "${connection.name}"`);
+      return client;
+    })().finally(() => this.pending.delete(connection.name));
+
+    this.pending.set(connection.name, promise);
+    return promise;
+  }
+
+  /** Alias for {@link addConnection}: return the connected client for `connection`, creating it if needed. */
+  getOrCreate(connection: McpClientConnection): Promise<McpClient> {
+    return this.addConnection(connection);
+  }
+
+  /**
+   * Disconnect and unregister every client registered under `name` (idempotent — a no-op if none
+   * exist). Mutates the registered collection in place so existing `getClients()` references stay
+   * valid.
+   */
+  async removeConnection(name: string): Promise<void> {
+    const removed: McpClient[] = [];
+    for (let i = this.clients.length - 1; i >= 0; i--) {
+      if (this.clients[i].name === name) removed.push(...this.clients.splice(i, 1));
+    }
+    await Promise.all(
+      removed.map((c) =>
+        c
+          .disconnect()
+          .catch((e) => this.logger.warn(`Failed to disconnect "${name}": ${String(e)}`)),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## What

Adds a runtime connection registry to `McpClientsService` so apps can register and tear down MCP **client** connections at runtime, instead of fixing every connection at `forRoot`/`forRootAsync` time.

New methods (purely additive — `getClient`/`getClients` are unchanged):

| Method | Description |
|---|---|
| `addConnection(connection)` | Create + connect a client and register it. Idempotent. |
| `getOrCreate(connection)` | Alias for `addConnection`. |
| `removeConnection(name)` | Disconnect + unregister (idempotent). |
| `has(name)` | Whether a client is registered under `name`. |

## Why

Multi-tenant gateways (e.g. an app where users register their own streamable-HTTP MCP servers) don't know their upstreams at module init. Today that forces hand-rolling a per-server `McpClient` cache outside the library. This lets you start with `forRoot({ connections: [] })` and add/remove connections on demand.

## Semantics

- **Idempotent**: a connected client with the same name is reused; a stale (disconnected) one is replaced; concurrent first-connects for the same name dedupe to a single client.
- A client whose `connect()` **rejects is not registered** — the error propagates.
- Runtime clients join the **same collection** as static ones, so they're returned by `getClient`/`getClients` and disconnected on application shutdown.
- Lookups/removal are **by name** — use unique names (e.g. a server id) for runtime connections.

## Tests / docs

- New `mcp-clients.service.runtime.spec.ts` (9 tests). Full client suite green: **211/211**, `tsc` build clean.
- Docs: runtime-connections section added to `docs/client/injection.md`.
- Changeset: `@nest-mcp/client` **minor**.

This is being dogfooded by a multi-tenant artifact gateway that consumes the registry to dispatch per-user streamable-HTTP MCP servers.